### PR TITLE
Windows 10 Hibernate & Clear Shutdown Timer

### DIFF
--- a/WinNUT_V2/WinNUT_GUI/Shutdown_Gui.vb
+++ b/WinNUT_V2/WinNUT_GUI/Shutdown_Gui.vb
@@ -97,6 +97,12 @@ Public Class Shutdown_Gui
         System.Threading.Thread.Sleep(1000)
         WinNUT.Shutdown_Action()
         Run_Timer.Enabled = False
+        Me.Shutdown_Timer.Stop()
+        Me.Shutdown_Timer.Enabled = False
+        Me.Grace_Timer.Stop()
+        Me.Grace_Timer.Enabled = False
+        Me.Hide()
+        Me.Close()
     End Sub
 
     Private Sub Run_Timer_Tick(sender As Object, e As EventArgs) Handles Run_Timer.Tick

--- a/WinNUT_V2/WinNUT_GUI/WinNUT.vb
+++ b/WinNUT_V2/WinNUT_GUI/WinNUT.vb
@@ -100,7 +100,7 @@ Public Class WinNUT
     Private Event On_Line()
     Private Event UpdateNotifyIconStr(ByVal Reason As String, ByVal Message As String)
     Private Event UpdateBatteryState(ByVal Reason As String)
-    Declare Function SetSystemPowerState Lib "kernel32" (ByVal fSuspend As Integer, ByVal fForce As Integer) As Integer
+    Declare Function SetSuspendState Lib "PowrProf" (ByVal Hibernate As Integer, ByVal ForceCritical As Integer, ByVal DisableWakeEvent As Integer) As Integer    
 
     Public Property UpdateMethod() As String
         Get
@@ -980,9 +980,9 @@ Public Class WinNUT
             Case 0
                 Process.Start("C:\WINDOWS\system32\Shutdown.exe", "-f -s -t 0")
             Case 1
-                SetSystemPowerState(True, 0)
+                SetSuspendState(False, False, True)  'Suspend
             Case 2
-                SetSystemPowerState(False, 0)
+                SetSuspendState(True, False, True)   'Hibernate
         End Select
     End Sub
 


### PR DESCRIPTION
Clone of @g-cranston 's pull request here: https://github.com/gawindx/WinNUT-Client/pull/125

Related: Issue #2 

> https://github.com/gawindx/WinNUT-Client/issues/89
> Allowing Hibernate/Suspend in Windows 10.
> 
> https://github.com/gawindx/WinNUT-Client/issues/123
> Clears the timer so that it doesn't repeat trying to shutdown after resuming the system.