### PR TITLE
Windows 10 Hibernate & Clear Shutdown Timer (redo)

### DIFF
--- a/WinNUT_V2/WinNUT_GUI/Shutdown_Gui.vb
+++ b/WinNUT_V2/WinNUT_GUI/Shutdown_Gui.vb
@@ -102,6 +102,12 @@ Public Class Shutdown_Gui
         System.Threading.Thread.Sleep(1000)
         WinNUT.Shutdown_Action()
         Run_Timer.Enabled = False
+        Me.Shutdown_Timer.Stop()
+        Me.Shutdown_Timer.Enabled = False
+        Me.Grace_Timer.Stop()
+        Me.Grace_Timer.Enabled = False
+        Me.Hide()
+        Me.Close()
     End Sub
 
     Private Sub Run_Timer_Tick(sender As Object, e As EventArgs) Handles Run_Timer.Tick

--- a/WinNUT_V2/WinNUT_GUI/WinNUT.vb
+++ b/WinNUT_V2/WinNUT_GUI/WinNUT.vb
@@ -428,27 +428,27 @@ Public Class WinNUT
         End If
     End Sub
 
-    Private Shared Sub NewRetry_NotifyIcon() Handles UPS_Device.New_Retry
-        Dim Message As String = String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_RETRY), WinNUT.UPS_Device.Retry, WinNUT.UPS_Device.MaxRetry)
+    Private Sub NewRetry_NotifyIcon() Handles UPS_Device.New_Retry
+        Dim Message As String = String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_RETRY), UPS_Device.Retry, UPS_Device.MaxRetry)
         RaiseEvent UpdateNotifyIconStr("Retry", Message)
-        WinNUT.UpdateIcon_NotifyIcon()
-        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, WinNUT)
+        UpdateIcon_NotifyIcon()
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
     End Sub
 
-    Private Shared Sub Reconnect_NotifyIcon() Handles UPS_Device.Connected
-        WinNUT.Menu_UPS_Var.Enabled = True
-        WinNUT.UpdateIcon_NotifyIcon()
-        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, WinNUT)
+    Private Sub Reconnect_NotifyIcon() Handles UPS_Device.Connected
+        Menu_UPS_Var.Enabled = True
+        UpdateIcon_NotifyIcon()
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
         RaiseEvent UpdateNotifyIconStr("Connected", Nothing)
     End Sub
 
-    Private Shared Sub Deconnected_NotifyIcon() Handles UPS_Device.Deconnected
-        WinNUT.ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
-        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, WinNUT)
-        WinNUT.UpdateIcon_NotifyIcon()
+    Private Sub Deconnected_NotifyIcon() Handles UPS_Device.Deconnected
+        ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
+        UpdateIcon_NotifyIcon()
         RaiseEvent UpdateNotifyIconStr("Deconnected", Nothing)
         RaiseEvent UpdateBatteryState("Deconnected")
-        WinNUT.Update_Data.Stop()
+        Update_Data.Stop()
     End Sub
 
     Private Sub Event_UpdateNotifyIconStr(ByVal Optional Reason As String = Nothing, ByVal Optional Message As String = Nothing) Handles Me.UpdateNotifyIconStr
@@ -537,13 +537,13 @@ Public Class WinNUT
         LogFile.LogTracing("Battery Status => " & Status, LogLvl.LOG_DEBUG, WinNUT)
     End Sub
 
-    Public Shared Sub Event_Unknown_UPS() Handles UPS_Device.Unknown_UPS, UPS_Device.Unknown_UPS
-        WinNUT.ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
-        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, WinNUT)
-        WinNUT.UpdateIcon_NotifyIcon()
+    Public Sub Event_Unknown_UPS() Handles UPS_Device.Unknown_UPS, UPS_Device.Unknown_UPS
+        ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
+        UpdateIcon_NotifyIcon()
         RaiseEvent UpdateNotifyIconStr("Unknown UPS", Nothing)
-        LogFile.LogTracing("Cannot Connect : Unknow UPS Name", LogLvl.LOG_DEBUG, WinNUT, WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_UNKNOWN_UPS))
-        WinNUT.Menu_UPS_Var.Enabled = False
+        LogFile.LogTracing("Cannot Connect : Unknow UPS Name", LogLvl.LOG_DEBUG, Me, WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_UNKNOWN_UPS))
+        Menu_UPS_Var.Enabled = False
     End Sub
 
     Private Sub Menu_About_Click(sender As Object, e As EventArgs) Handles Menu_About.Click
@@ -560,27 +560,25 @@ Public Class WinNUT
         HasFocus = False
     End Sub
 
-    Private Shared Sub UPS_Lostconnect() Handles UPS_Device.Lost_Connect
-        With WinNUT
-            Dim Host = .Nut_Config.Host
-            Dim Port = .Nut_Config.Port
-            .Update_Data.Stop()
-            LogFile.LogTracing("Nut Server Lost Connection", LogLvl.LOG_ERROR, WinNUT, String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_LOSTCONNECT), Host, Port))
-            LogFile.LogTracing("Fix All data to null/empty String", LogLvl.LOG_DEBUG, WinNUT)
-            LogFile.LogTracing("Fix All Dial Data to Min Value/0", LogLvl.LOG_DEBUG, WinNUT)
+    Private Sub UPS_Lostconnect() Handles UPS_Device.Lost_Connect
+        Dim Host = Nut_Config.Host
+        Dim Port = Nut_Config.Port
+        Update_Data.Stop()
+        LogFile.LogTracing("Nut Server Lost Connection", LogLvl.LOG_ERROR, Me, String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_MAIN_LOSTCONNECT), Host, Port))
+        LogFile.LogTracing("Fix All data to null/empty String", LogLvl.LOG_DEBUG, Me)
+        LogFile.LogTracing("Fix All Dial Data to Min Value/0", LogLvl.LOG_DEBUG, Me)
 
-            .ReInitDisplayValues()
-            If .AutoReconnect And .UPS_Retry <= .UPS_MaxRetry Then
-                .ActualAppIconIdx = AppIconIdx.IDX_ICO_RETRY
-            Else
-                .ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
-            End If
+        ReInitDisplayValues()
+        If AutoReconnect And UPS_Retry <= UPS_MaxRetry Then
+            ActualAppIconIdx = AppIconIdx.IDX_ICO_RETRY
+        Else
+            ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
+        End If
 
-            .UpdateIcon_NotifyIcon()
-            RaiseEvent UpdateNotifyIconStr("Lost Connect", Nothing)
-            RaiseEvent UpdateBatteryState("Lost Connect")
-            LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, WinNUT)
-        End With
+        UpdateIcon_NotifyIcon()
+        RaiseEvent UpdateNotifyIconStr("Lost Connect", Nothing)
+        RaiseEvent UpdateBatteryState("Lost Connect")
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
     End Sub
 
     Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,

--- a/WinNUT_V2/WinNUT_GUI/WinNUT.vb
+++ b/WinNUT_V2/WinNUT_GUI/WinNUT.vb
@@ -62,11 +62,11 @@ Public Class WinNUT
     Private Event On_Battery()
     Private Event On_Line()
     Private Event Data_Updated()
-    Private Shared Event UpdateNotifyIconStr(ByVal Reason As String, ByVal Message As String)
-    Private Shared Event UpdateBatteryState(ByVal Reason As String)
+    Private Event UpdateNotifyIconStr(ByVal Reason As String, ByVal Message As String)
+    Private Event UpdateBatteryState(ByVal Reason As String)
 
     'Handle sleep/hibernate mode from windows API
-    Declare Function SetSystemPowerState Lib "kernel32" (ByVal fSuspend As Integer, ByVal fForce As Integer) As Integer
+	Declare Function SetSuspendState Lib "PowrProf" (ByVal Hibernate As Integer, ByVal ForceCritical As Integer, ByVal DisableWakeEvent As Integer) As Integer    
 
     Public Property UpdateMethod() As String
         Get
@@ -1039,9 +1039,9 @@ Public Class WinNUT
             Case 0
                 Process.Start("C:\WINDOWS\system32\Shutdown.exe", "-f -s -t 0")
             Case 1
-                SetSystemPowerState(True, 0)
+                SetSuspendState(False, False, True)  'Suspend
             Case 2
-                SetSystemPowerState(False, 0)
+                SetSuspendState(True, False, True)   'Hibernate
         End Select
     End Sub
 


### PR DESCRIPTION
Clone of @g-cranston 's pull request here: https://github.com/gawindx/WinNUT-Client/pull/125

Related: Issue https://github.com/nutdotnet/WinNUT-Client/issues/2

**Original text:**

https://github.com/gawindx/WinNUT-Client/issues/89
Allowing Hibernate/Suspend in Windows 10.

https://github.com/gawindx/WinNUT-Client/issues/123
Clears the timer so that it doesn't repeat trying to shutdown after resuming the system.