### PR TITLE
Small updates to german Translation

### DIFF
--- a/Translation/de-DE/de-DE.csv
+++ b/Translation/de-DE/de-DE.csv
@@ -1,5 +1,5 @@
 ﻿Status,Translator,﻿Message,Translation
-Valid,Gawindx,About,Über
+To be Validated,Martin Kurtz,About,Impressum
 Valid,Lineflyer,Activate automatic connection / reconnection,Automatische Verbindung / Wiederverbindung aktivieren
 Valid,Lineflyer,Additional grace period limit. Accepted value: Numeric value from 0 to 3600., Limit für zusätzliche Verzögerung. Wertebereich: Numerischer Wert von 0 bis 3600.
 Valid,Lineflyer,Alert,Alarm
@@ -36,8 +36,8 @@ Valid,Lineflyer,Delay to Shutdown (sec),Verzögerung vor dem Herunterfahren (Sek
 Valid,Lineflyer,Delete log file.,Logdatei löschen.
 Valid,Gawindx,Description :,Beschreibung :
 Valid,Gawindx,Devellopement,Entwicklung
-Valid,Gawindx,Disconnect,Trennen
-Valid,Lineflyer,Disconnected from Nut Host,Vom NUT-Host getrennt
+To be Validated,Martin Kurtz,Disconnect,Verbindung trennen
+To be Validated,Martin Kurtz,Disconnected from Nut Host,Verbindung zum NUT-Host verloren
 Valid,Gawindx,Download New Version from :,Neue Version herunterladen von :
 Valid,Lineflyer,Error,Fehler
 Valid,Lineflyer,Exit,Beenden
@@ -61,8 +61,8 @@ Valid,Gawindx,Input Voltage,Eingangsspannung
 Valid,Gawindx,Item Properties,Eigenschaften
 Valid,Lineflyer,List UPS Variables,Liste der USV-Variablen
 Valid,Lineflyer,Log file log level,Detailstufe für die Logdatei
-Valid,Lineflyer,Logging level,Detailstufe
-Valid,Lineflyer,Logging level.,Detailstufe.
+To be Validated,Martin Kurtz,Logging level,Detailstufe des Logs
+To be Validated,Martin Kurtz,Logging level.,Detailstufe des Logs.
 Valid,Lineflyer,Login,Anmeldung
 Valid,Lineflyer,Login credentials to the Nut server (leave blank if not required),Anmeldeinformationen des NUT-Server (Leer lassen wenn nicht erforderlich)
 Valid,Lineflyer,Lost Connect To {0}:{1},Verbindung zu {0}:{1} verloren
@@ -113,7 +113,7 @@ Valid,Lineflyer,Re-establish connection,Verbindung wiederherstellen
 Valid,Gawindx,Reload,Neu laden
 Valid,Gawindx,Remaining Time :,Verbleibende Zeit :
 Valid,Gawindx,Restarting WinNUT after waking up from Windows.,Neustart von WinNUT nach dem Aufwachen von Windows.
-Valid,Lineflyer,Sends in Systray at closing.,Minimiert beim Schließen in den Systray.
+To be Validated,Martin Kurtz,Sends in Systray at closing.,Ins Systray minimieren anstatt zu schliessen.
 Valid,Gawindx,Serial :,Seriennummer:
 Valid,Lineflyer,Sets the input frequency if not supplied by the UPS.,Legt die Eingangsfrequenz fest wenn dieser Wert nicht von der USV geliefert wird.
 Valid,Lineflyer,Settings,Einstellungen
@@ -142,7 +142,7 @@ Valid,Gawindx,Unknown UPS Name,Unbekannter USV-Name
 Valid,Gawindx,Update,Aktualisieren
 Valid,Gawindx,Update Available : Version {0},Update verfügbar : Version {0}
 Valid,Lineflyer,Update WinNUT-Client Now? Ok to Close WinNut and Install New Version Cancel to Save Msi and Install Later,WinNUT-Client jetzt aktualisieren? OK um WinNUT zu schließen und neue Version zu installieren Abbrechen um MSI-Datei zu speichern und später zu installieren
-Valid,Gawindx,UPS Battery Low,USV-Batterie schwach
+To be Validated,Martin Kurtz,UPS Battery Low,USV-Akkuladung niedrig
 Valid,Lineflyer,UPS Load,USV-Last
 Valid,Lineflyer,UPS Name,USV-Name
 Valid,Lineflyer,UPS name to monitor. Accepted Value: Name of the UPS configured in the Nut server.,Name der zu überwachenden USV. Wertebereich: Name der auf dem NUT-Server konfigurierten USV.

--- a/Translation/de-DE/de-DE.csv
+++ b/Translation/de-DE/de-DE.csv
@@ -8,11 +8,11 @@ Valid,Lineflyer,Allow Extended Shutdown Time,Längere Abschaltzeit zulassen
 Valid,Gawindx,Application shut down at,Anwendung heruntergefahren um
 Valid,Gawindx,Apply,Anwenden
 Valid,Gawindx,Automatic Reconnection,Automatische Wiederverbindung
-Valid,Gawindx,Battery Charge,Batterieladung
-Valid,Gawindx,Battery OK,Batterie OK
-Valid,Gawindx,Battery Voltage,Batteriespannung
-Valid,Gawindx,Battery_Charge : {0} Remaining Time : {1},Batterieladung: {0} Verbleibende Zeit: {1}
-Valid,Gawindx,Battery_Charge : {WinNUT.UPS_BattCh} Remaining Time : {WinNUT.Lbl_VRTime.Text},Batterieladung: {WinNUT.UPS_BattCh} Verbleibende Zeit: {WinNUT.Lbl_VRTime.Text}
+To be Validated,Martin Kurtz,Battery Charge,Akkuladung
+To be Validated,Martin Kurtz,Battery OK,Akku OK
+To be Validated,Martin Kurtz,Battery Voltage,Akkuspannung
+To be Validated,Martin Kurtz,Battery_Charge : {0} Remaining Time : {1},Akkuladung: {0} Verbleibende Zeit: {1}
+To be Validated,Martin Kurtz,Battery_Charge : {WinNUT.UPS_BattCh} Remaining Time : {WinNUT.Lbl_VRTime.Text},Akkuladungladung: {WinNUT.UPS_BattCh} Verbleibende Zeit: {WinNUT.Lbl_VRTime.Text}
 Valid,Gawindx,Calibration,Kalibrierung
 Valid,Lineflyer,Cancel,Abbrechen
 To validate,Lineflyer,Cancellation of the Extinguishing Process,Abbruch des Löschprozesses
@@ -66,20 +66,20 @@ To be Validated,Martin Kurtz,Logging level.,Detailstufe des Logs.
 Valid,Lineflyer,Login,Anmeldung
 Valid,Lineflyer,Login credentials to the Nut server (leave blank if not required),Anmeldeinformationen des NUT-Server (Leer lassen wenn nicht erforderlich)
 Valid,Lineflyer,Lost Connect To {0}:{1},Verbindung zu {0}:{1} verloren
-Valid,Gawindx,Low Battery,Niedriger Batteriestatus
+To be Validated,Martin Kurtz,Low Battery,Niedrige Akkuladung
 Valid,Lineflyer,Lower backup time limit triggering the shutdown procedure. Accepted value: Numeric value from 0 to 3600.,Unteres Backup-Zeitlimit welches das Herunterfahren auslöst. Wertebereich: Numerischer Wert von 0 bis 3600.
-Valid,Lineflyer,Lower limit of the battery level triggering the shutdown procedure. Accepted value: Numeric value from 0 to 100.,Untergrenze des Batteriestands der den Abschaltvorgang auslöst. Wertebereich: Numerischer Wert von 0 bis 100.
+To be Validated,Martin Kurtz,Lower limit of the battery level triggering the shutdown procedure. Accepted value: Numeric value from 0 to 100.,Untergrenze des Akkustands der den Abschaltvorgang auslöst. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Gawindx,Manufacturer :,Hersteller:
 Valid,Gawindx,Max,Max
 Valid,Lineflyer,Max Retry reached. Wait for manual Reconnection,Maximale Anzahl Verbindungsversuche erreicht. Auf manuelle Wiederverbindung warten.
-Valid,Lineflyer,Maximum Battery Voltage. Accepted value: Numeric value from 0 to 100.,Maximale Batteriespannung. Wertebereich: Numerischer Wert von 0 bis 100.
+To be Validated,Martin Kurtz,Maximum Battery Voltage. Accepted value: Numeric value from 0 to 100.,Maximale Akkuspannung. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Maximum input frequency. Accepted value: Numeric value from 0 to 100.,Maximale Eingangsfrequenz. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Maximum input voltage. Accepted value: Numeric value from 0 to 999.,Maximale Eingangsspannung. Wertebereich: Numerischer Wert von 0 bis 999.
 Valid,Lineflyer,Maximum Load Level of the UPS. Accepted value: Numeric value from 0 to 100.,Maximaler Last der USV. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Maximum Output Voltage. Accepted value: Numeric value from 0 to 999.,Maximale Ausgangsspannung. Wertebereich: Numerischer Wert von 0 bis 999.
 Valid,Gawindx,Min,Min
 Valid,Gawindx,Minimize to Systray,In Systray minimieren
-Valid,Lineflyer,Minimum Battery Voltage. Accepted value: Numeric value from 0 to 100.,Minimale Batteriespannung. Wertebereich: Numerischer Wert von 0 bis 100.
+To be Validated,Martin Kurtz,Minimum Battery Voltage. Accepted value: Numeric value from 0 to 100.,Minimale Akkuspannung. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Minimum Charge Level of the UPS. Accepted value: Numeric value from 0 to 100.,Mindestladezustand der USV. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Minimum input frequency. Accepted value: Numeric value from 0 to 100.,Minimale Eingangsfrequenz. Wertebereich: Numerischer Wert von 0 bis 100.
 Valid,Lineflyer,Minimum input voltage. Accepted value: Numeric value from 0 to 999.,Minimale Eingangsspannung. Wertebereich: Numerischer Wert von 0 bis 999.
@@ -99,7 +99,7 @@ Valid,Lineflyer,Nut Server Port Number (default = 3493). Accepted value: Numeric
 Valid,Gawindx,Ok,OK
 Valid,Gawindx,Old ups.ini imported,Alte ups.ini importiert
 Valid,Lineflyer,Old ups.ini imported Ini File Moved to {0}.old,Alte ups.ini importiert INI-Datei nach {0}.old verschoben
-To validate,Lineflyer,On Battery ({0}%),Im Batteriebetrieb ({0}%)
+To be Validated,Martin Kurtz,On Battery ({0}%),Im Akkubetrieb ({0}%)
 To validate,Lineflyer,On Line,Im Netzbetrieb
 Valid,Lineflyer,Open the log file.,Logdatei öffnen.
 Valid,Gawindx,Options,Optionen
@@ -119,7 +119,7 @@ Valid,Lineflyer,Sets the input frequency if not supplied by the UPS.,Legt die Ei
 Valid,Lineflyer,Settings,Einstellungen
 Valid,Lineflyer,Show ChangeLog,Change-Log anzeigen
 Valid,Lineflyer,Shutdown,Herunterfahren
-Valid,Lineflyer,Shutdown if battery lower than,Herunterfahren wenn Batteriestand niedriger als
+To be Validated,Martin Kurtz,Shutdown if battery lower than,Herunterfahren wenn Akkuladung weniger als
 Valid,Lineflyer,Shutdown if runtime lower than (sec),Herunterfahren wenn Laufzeit niedriger als (Sek.)
 Valid,Lineflyer,Shutdown on NUT's FSD Signal,Herunterfahren bei FSD-Signal des NUT
 Valid,Gawindx,Shutdown Options,Optionen zum Herunterfahren
@@ -146,7 +146,7 @@ To be Validated,Martin Kurtz,UPS Battery Low,USV-Akkuladung niedrig
 Valid,Lineflyer,UPS Load,USV-Last
 Valid,Lineflyer,UPS Name,USV-Name
 Valid,Lineflyer,UPS name to monitor. Accepted Value: Name of the UPS configured in the Nut server.,Name der zu überwachenden USV. Wertebereich: Name der auf dem NUT-Server konfigurierten USV.
-Valid,Gawindx,UPS On Battery,USV im Batteriebetrieb
+To be Validated,Martin Kurtz,UPS On Battery,USV im Akkubetrieb
 Valid,Lineflyer,UPS On Line,USV im Netzbetrieb
 Valid,Gawindx,UPS Overload,USV-Überlastung
 Valid,Lineflyer,UPS Variable,USV-Variablen


### PR DESCRIPTION
I made some small updates to the german translation and changed the german word Batterie to Akku as i believe it to be more fitting.

There also some "To Validate" lines, that i would consider good, however i do not know your procedure for validating, so i did not touch them, however i could validate some of them, as they make perfect sense to me