### PR TITLE
Re-activate stop actions system and status updates overhaul

### DIFF
--- a/WinNUT_V2/WinNUT-Client/Shutdown_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/Shutdown_Gui.vb
@@ -7,16 +7,14 @@
 '
 ' This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY
 
-Imports WinNUT_Params = WinNUT_Client_Common.WinNUT_Params
-Imports Logger = WinNUT_Client_Common.Logger
 Imports LogLvl = WinNUT_Client_Common.LogLvl
 Imports AppResxStr = WinNUT_Client_Common.AppResxStr
-Imports WinNUT_Globals = WinNUT_Client_Common.WinNUT_Globals
+Imports WinNUT_Client_Common
+
 Public Class Shutdown_Gui
-    Private LogFile As Logger
     Private RedText As Boolean = True
     Private ReadOnly Shutdown_PBar As New WinFormControls.CProgressBar
-    Private Start_Shutdown As DateTime
+    Private Start_Shutdown As Date
     Private Offset_STimer As Double = 0
     Private STimer As Double = 0
     Private Remained As Double = 0
@@ -24,31 +22,30 @@ Public Class Shutdown_Gui
     Public Shutdown_Timer As New Timer
 
     Private Sub Grace_Button_Click(sender As Object, e As EventArgs) Handles Grace_Button.Click
-        Me.Shutdown_Timer.Stop()
-        Me.Shutdown_Timer.Enabled = False
+        Shutdown_Timer.Stop()
+        Shutdown_Timer.Enabled = False
         Grace_Button.Enabled = False
-        Me.Grace_Timer.Enabled = True
-        Me.Grace_Timer.Start()
-        Me.Offset_STimer = WinNUT_Params.Arr_Reg_Key.Item("ExtendedShutdownDelay")
+        Grace_Timer.Enabled = True
+        Grace_Timer.Start()
+        Offset_STimer = Arr_Reg_Key.Item("ExtendedShutdownDelay")
     End Sub
 
     Private Sub Shutdown_Gui_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        Me.Icon = WinNUT.Icon
-        ' Me.LogFile = WinNUT.LogFile
+        Icon = WinNUT.Icon
         LogFile.LogTracing("Load ShutDown Gui", LogLvl.LOG_DEBUG, Me)
-        Me.Grace_Timer.Enabled = False
-        Me.Grace_Timer.Stop()
+        Grace_Timer.Enabled = False
+        Grace_Timer.Stop()
         'If ExtendedShutdownDelay = 0 (the default value), the next line fails and the whole shutdown sequence fails - Thus no shutdown
         'Moved next line lower down
         'Me.Grace_Timer.Interval = (WinNUT_Params.Arr_Reg_Key.Item("ExtendedShutdownDelay") * 1000)
-        Shutdown_Timer.Interval = (WinNUT_Params.Arr_Reg_Key.Item("DelayToShutdown") * 1000)
-        Me.STimer = WinNUT_Params.Arr_Reg_Key.Item("DelayToShutdown")
-        Me.Remained = Me.STimer
-        If WinNUT_Params.Arr_Reg_Key.Item("AllowExtendedShutdownDelay") Then
+        Shutdown_Timer.Interval = (Arr_Reg_Key.Item("DelayToShutdown") * 1000)
+        STimer = Arr_Reg_Key.Item("DelayToShutdown")
+        Remained = STimer
+        If Arr_Reg_Key.Item("AllowExtendedShutdownDelay") Then
             Grace_Button.Enabled = True
             'Moved here so it is only used if grace period is allowed
             Try
-                Me.Grace_Timer.Interval = (WinNUT_Params.Arr_Reg_Key.Item("ExtendedShutdownDelay") * 1000)
+                Grace_Timer.Interval = (Arr_Reg_Key.Item("ExtendedShutdownDelay") * 1000)
             Catch ex As Exception
                 'Disable Grace peroid option if Interval is set to 0
                 Grace_Button.Enabled = False
@@ -76,21 +73,22 @@ Public Class Shutdown_Gui
             .Text = TimeToShow
             .Value = 0
         End With
-        Me.Controls.Add(Shutdown_PBar)
+        Controls.Add(Shutdown_PBar)
         AddHandler Grace_Timer.Tick, AddressOf Grace_Timer_Tick
         AddHandler Shutdown_Timer.Tick, AddressOf Shutdown_Timer_Tick
     End Sub
 
     Private Sub Shutdown_Gui_Shown(sender As Object, e As EventArgs) Handles MyBase.Shown
-        Me.Shutdown_Timer.Enabled = True
-        Me.Shutdown_Timer.Start()
-        lbl_UPSStatus.Text = String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_SHUT_STAT), WinNUT.UPS_BattCh.ToString(), WinNUT.Lbl_VRTime.Text)
+        Shutdown_Timer.Enabled = True
+        Shutdown_Timer.Start()
+        lbl_UPSStatus.Text = String.Format(StrLog.Item(AppResxStr.STR_SHUT_STAT), WinNUT.UPS_BattCh.ToString(), WinNUT.Lbl_VRTime.Text)
+        LogFile.LogTracing("Shutdown GUI is shown and timer started for " & Shutdown_Timer.Interval / 1000 & " seconds.", LogLvl.LOG_NOTICE, Me)
     End Sub
 
     Private Sub Grace_Timer_Tick(sender As Object, e As EventArgs)
-        Me.Shutdown_Timer.Interval = Me.Remained * 1000
-        Me.Shutdown_Timer.Enabled = True
-        Me.Shutdown_Timer.Start()
+        Shutdown_Timer.Interval = Remained * 1000
+        Shutdown_Timer.Enabled = True
+        Shutdown_Timer.Start()
     End Sub
 
     Private Sub ShutDown_Btn_Click(sender As Object, e As EventArgs) Handles ShutDown_Btn.Click
@@ -98,16 +96,18 @@ Public Class Shutdown_Gui
     End Sub
 
     Private Sub Shutdown_Timer_Tick(sender As Object, e As EventArgs)
+        LogFile.LogTracing("Shutdown timer tick.", LogLvl.LOG_NOTICE, Me)
         Shutdown_PBar.Value = 100
-        System.Threading.Thread.Sleep(1000)
-        WinNUT.Shutdown_Action()
+        Threading.Thread.Sleep(1000)
         Run_Timer.Enabled = False
-        Me.Shutdown_Timer.Stop()
-        Me.Shutdown_Timer.Enabled = False
-        Me.Grace_Timer.Stop()
-        Me.Grace_Timer.Enabled = False
-        Me.Hide()
-        Me.Close()
+        Shutdown_Timer.Stop()
+        Shutdown_Timer.Enabled = False
+        Grace_Timer.Stop()
+        Grace_Timer.Enabled = False
+        Hide()
+        WinNUT.Shutdown_Action()
+
+        Close()
     End Sub
 
     Private Sub Run_Timer_Tick(sender As Object, e As EventArgs) Handles Run_Timer.Tick
@@ -118,18 +118,18 @@ Public Class Shutdown_Gui
             lbl_UPSStatus.ForeColor = Color.Black
             RedText = True
         End If
-        If Me.Shutdown_Timer.Enabled = True And Me.Remained > 0 Then
-            Me.Remained = Int(STimer + Offset_STimer - Now.Subtract(Start_Shutdown).TotalSeconds)
+        If Shutdown_Timer.Enabled = True And Remained > 0 Then
+            Remained = Int(STimer + Offset_STimer - Now.Subtract(Start_Shutdown).TotalSeconds)
             Dim NewValue As Integer = 100
-            If Me.Remained > 0 Then
-                NewValue -= (100 * (Me.Remained / Me.STimer))
+            If Remained > 0 Then
+                NewValue -= (100 * (Remained / STimer))
                 If NewValue > 100 Then
                     NewValue = 100
                 End If
             End If
             Dim TimeToShow As String
-            Dim iSpan As TimeSpan = TimeSpan.FromSeconds(Me.Remained)
-            If Me.Shutdown_Timer.Interval = (3600 * 1000) Then
+            Dim iSpan As TimeSpan = TimeSpan.FromSeconds(Remained)
+            If Shutdown_Timer.Interval = (3600 * 1000) Then
                 TimeToShow = iSpan.Hours.ToString.PadLeft(2, "0"c) & ":" &
                                         iSpan.Minutes.ToString.PadLeft(2, "0"c) & ":" &
                                         iSpan.Seconds.ToString.PadLeft(2, "0"c)
@@ -139,12 +139,12 @@ Public Class Shutdown_Gui
             End If
             Shutdown_PBar.Text = TimeToShow
             Shutdown_PBar.Value = NewValue
-            lbl_UPSStatus.Text = String.Format(WinNUT_Globals.StrLog.Item(AppResxStr.STR_SHUT_STAT), WinNUT.UPS_BattCh.ToString(), WinNUT.Lbl_VRTime.Text)
+            lbl_UPSStatus.Text = String.Format(StrLog.Item(AppResxStr.STR_SHUT_STAT), WinNUT.UPS_BattCh.ToString(), WinNUT.Lbl_VRTime.Text)
         End If
     End Sub
 
     Private Sub Shutdown_Gui_FormClosing(sender As Object, e As FormClosingEventArgs) Handles MyBase.FormClosing
-        If Me.Visible Then
+        If Visible Then
             e.Cancel = True
         End If
     End Sub

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -281,7 +281,7 @@ Public Class WinNUT
     End Sub
 
     Private Sub SystemEvents_PowerModeChanged(sender As Object, e As Microsoft.Win32.PowerModeChangedEventArgs)
-        LogFile.LogTracing("PowerModeChangedEvent: " & e.Mode, LogLvl.LOG_NOTICE, Me)
+        LogFile.LogTracing("PowerModeChangedEvent: " & [Enum].GetName(GetType(Microsoft.Win32.PowerModes), e.Mode), LogLvl.LOG_NOTICE, Me)
         Select Case e.Mode
             Case Microsoft.Win32.PowerModes.Resume
                 LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
@@ -334,7 +334,6 @@ Public Class WinNUT
                                sender.Name, sender.IsConnected, sender.IsAuthenticated), LogLvl.LOG_ERROR, Me,
                                String.Format(StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), sender.Nut_Config.Host, sender.Nut_Config.Port,
                                              ex.Message))
-        UPSDisconnect()
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -286,12 +286,12 @@ Public Class WinNUT
             Case Microsoft.Win32.PowerModes.Resume
                 LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
                 If Arr_Reg_Key.Item("AutoReconnect") = True Then
-                    UPS_Connect()
+                    UPS_Connect(True)
                 End If
         End Select
     End Sub
 
-    Private Sub UPS_Connect()
+    Private Sub UPS_Connect(Optional retryOnConnFailure = False)
         Dim Nut_Config As Nut_Parameter
         LogFile.LogTracing("Client UPS_Connect subroutine beginning.", LogLvl.LOG_NOTICE, Me)
 
@@ -303,7 +303,7 @@ Public Class WinNUT
                                        Arr_Reg_Key.Item("AutoReconnect"))
 
         UPS_Device = New UPS_Device(Nut_Config, LogFile, Arr_Reg_Key.Item("Delay"))
-        UPS_Device.Connect_UPS()
+        UPS_Device.Connect_UPS(retryOnConnFailure)
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -281,16 +281,13 @@ Public Class WinNUT
     End Sub
 
     Private Sub SystemEvents_PowerModeChanged(sender As Object, e As Microsoft.Win32.PowerModeChangedEventArgs)
-        LogFile.LogTracing("PowerModeChangedEvent: " & e.ToString(), LogLvl.LOG_NOTICE, Me)
+        LogFile.LogTracing("PowerModeChangedEvent: " & e.Mode, LogLvl.LOG_NOTICE, Me)
         Select Case e.Mode
             Case Microsoft.Win32.PowerModes.Resume
                 LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
                 If Arr_Reg_Key.Item("AutoReconnect") = True Then
                     UPS_Connect()
                 End If
-            Case Microsoft.Win32.PowerModes.Suspend
-                LogFile.LogTracing("Windows standby, WinNUT will disconnect", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
-                UPSDisconnect()
         End Select
     End Sub
 
@@ -1098,7 +1095,9 @@ Public Class WinNUT
 
     Public Sub Shutdown_Action()
         Dim stopAction = Arr_Reg_Key.Item("TypeOfStop")
-        LogFile.LogTracing("Executing stop action " & stopAction, LogLvl.LOG_NOTICE, Me)
+        LogFile.LogTracing("Windows going down, WinNUT will disconnect.", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
+        UPSDisconnect()
+
         Select Case stopAction
             Case 0
                 Process.Start("C:\WINDOWS\system32\Shutdown.exe", "-f -s -t 0")

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -299,7 +299,7 @@ Public Class WinNUT
 
     Private Sub UPS_Connect()
         Dim Nut_Config As Nut_Parameter
-        ' LogFile.LogTracing("Client UPS_Connect subroutine beginning.", LogLvl.LOG_NOTICE, Me)
+        LogFile.LogTracing("Client UPS_Connect subroutine beginning.", LogLvl.LOG_NOTICE, Me)
 
         Nut_Config = New Nut_Parameter(Arr_Reg_Key.Item("ServerAddress"),
                                        Arr_Reg_Key.Item("Port"),
@@ -326,20 +326,21 @@ Public Class WinNUT
         '    ' .Enabled = True
         'End With
 
-        If Not (UPS_Device.IsConnected And UPS_Device.IsAuthenticated) Then
-            LogFile.LogTracing(String.Format("Something went wrong connecting to UPS {0}. IsConnected: {1}, IsAuthenticated: {2}",
-                               upsConf.UPSName, UPS_Device.IsConnected, UPS_Device.IsAuthenticated), LogLvl.LOG_ERROR, Me,
-                               String.Format(StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), upsConf.Host, upsConf.Port, "Connection Error"))
-            UPSDisconnect()
-        Else
-            Menu_UPS_Var.Enabled = True
-            UpdateIcon_NotifyIcon()
-            LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
-            RaiseEvent UpdateNotifyIconStr("Connected", Nothing)
-            LogFile.LogTracing("Connection to Nut Host Established", LogLvl.LOG_NOTICE, Me,
-                               String.Format(StrLog.Item(AppResxStr.STR_LOG_CONNECTED),
-                                             upsConf.Host, upsConf.Port))
-        End If
+        Menu_UPS_Var.Enabled = True
+        UpdateIcon_NotifyIcon()
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
+        RaiseEvent UpdateNotifyIconStr("Connected", Nothing)
+        LogFile.LogTracing("Connection to Nut Host Established", LogLvl.LOG_NOTICE, Me,
+                           String.Format(StrLog.Item(AppResxStr.STR_LOG_CONNECTED),
+                                         upsConf.Host, upsConf.Port))
+    End Sub
+
+    Private Sub ConnectionError(sender As UPS_Device, ex As Exception) Handles UPS_Device.ConnectionError
+        LogFile.LogTracing(String.Format("Something went wrong connecting to UPS {0}. IsConnected: {1}, IsAuthenticated: {2}",
+                               sender.Name, sender.IsConnected, sender.IsAuthenticated), LogLvl.LOG_ERROR, Me,
+                               String.Format(StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), sender.Nut_Config.Host, sender.Nut_Config.Port,
+                                             ex.Message))
+        UPSDisconnect()
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -84,10 +84,6 @@ Public Class WinNUT
     Private Event UpdateBatteryState(Reason As String)
     ' UPS object operation 
     Private Event RequestConnect()
-    ' Private Event RequestDisconnect()
-
-    'Handle sleep/hibernate mode from windows API
-    Declare Function SetSuspendState Lib "PowrProf" (Hibernate As Integer, ForceCritical As Integer, DisableWakeEvent As Integer) As Integer
 
     Private Sub WinNUT_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         ' Make sure we have an app directory to write to.
@@ -285,6 +281,7 @@ Public Class WinNUT
     End Sub
 
     Private Sub SystemEvents_PowerModeChanged(sender As Object, e As Microsoft.Win32.PowerModeChangedEventArgs)
+        LogFile.LogTracing("PowerModeChangedEvent: " & e.ToString(), LogLvl.LOG_NOTICE, Me)
         Select Case e.Mode
             Case Microsoft.Win32.PowerModes.Resume
                 LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
@@ -1100,13 +1097,15 @@ Public Class WinNUT
     End Sub
 
     Public Sub Shutdown_Action()
-        Select Case Arr_Reg_Key.Item("TypeOfStop")
+        Dim stopAction = Arr_Reg_Key.Item("TypeOfStop")
+        LogFile.LogTracing("Executing stop action " & stopAction, LogLvl.LOG_NOTICE, Me)
+        Select Case stopAction
             Case 0
                 Process.Start("C:\WINDOWS\system32\Shutdown.exe", "-f -s -t 0")
             Case 1
-                SetSuspendState(False, False, True)  'Suspend
+                Application.SetSuspendState(PowerState.Suspend, False, True)
             Case 2
-                SetSuspendState(True, False, True)   'Hibernate
+                Application.SetSuspendState(PowerState.Hibernate, False, True)
         End Select
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client_Common/Common_Classes.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Common_Classes.vb
@@ -20,7 +20,7 @@ Public Class UPS_Values
     Public Load As Double = Nothing
     Public Output_Power As Double = Nothing
     Public Batt_Capacity As Double = Nothing
-    Public UPS_Status As Integer = Nothing
+    Public UPS_Status As UPS_States = Nothing
 End Class
 
 Public Class UPSData
@@ -36,7 +36,6 @@ Public Class UPSData
         Me.Serial = Serial
         Me.Firmware = Firmware
     End Sub
-
 End Class
 
 ''' <summary>

--- a/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
@@ -99,17 +99,20 @@ Public Enum NUTResponse
     ENDLIST
 End Enum
 
+<Flags()>
 Public Enum UPS_States
-    OL = 1
-    OB = 2
-    LBHB = 4
-    CHRG = 8
-    DISCHRG = 16
-    FSD = 32
-    BYPASS = 64
-    CAL = 128
-    OFF = 256
-    OVER = 512
-    TRIM = 1024
-    BOOST = 2048
+    None
+    OL
+    OB
+    LB
+    HB
+    CHRG
+    DISCHRG
+    FSD
+    BYPASS
+    CAL
+    OFF
+    OVER
+    TRIM
+    BOOST
 End Enum

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -206,13 +206,13 @@ Public Class Nut_Socket
         streamInUse = True
 
         If ConnectionStatus Then
-            LogFile.LogTracing("Sending query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
+            ' LogFile.LogTracing("Sending query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
             WriterStream.WriteLine(Query_Msg & vbCr)
             WriterStream.Flush()
 
             DataResult = Trim(ReaderStream.ReadLine())
             streamInUse = False
-            LogFile.LogTracing("Done processing response for query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
+            ' LogFile.LogTracing("Done processing response for query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
 
             Response = EnumResponse(DataResult)
             finalTransaction = New Transaction(Query_Msg, DataResult, Response)
@@ -238,7 +238,7 @@ Public Class Nut_Socket
         Dim start As Date = Date.Now
 
         ' Read in first line to get initial response.
-        LogFile.LogTracing("Sending LIST query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
+        ' LogFile.LogTracing("Sending LIST query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
         Dim response = Query_Data(Query_Msg)
         streamInUse = True
         Dim readLine As String
@@ -252,7 +252,7 @@ Public Class Nut_Socket
         Loop Until (IsNothing(readLine) Or (ReaderStream.Peek < 0))
 
         streamInUse = False
-        LogFile.LogTracing("Done processing LIST response for query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
+        ' LogFile.LogTracing("Done processing LIST response for query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
 
         Dim Key As String
         Dim Value As String

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -140,18 +140,15 @@ Public Class Nut_Socket
     Public Sub Disconnect(Optional silent = False, Optional forceful = False)
         ' WatchDog.Stop()
 
-        If Not forceful Then
+        If IsConnected AndAlso Not forceful Then
             Query_Data("LOGOUT")
         End If
 
         Close_Socket()
 
         If Not silent Then
-            LogFile.LogTracing("NutSocket raising Disconnected event.", LogLvl.LOG_DEBUG, Me)
             RaiseEvent SocketDisconnected()
         End If
-
-        LogFile.LogTracing("NutSocket has been Disconnected.", LogLvl.LOG_DEBUG, Me)
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -13,6 +13,12 @@ Imports System.Windows.Forms
 Public Class UPS_Device
 #Region "Properties"
 
+    Public ReadOnly Property Name As String
+        Get
+            Return Nut_Config.UPSName
+        End Get
+    End Property
+
     Public ReadOnly Property IsConnected As Boolean
         Get
             Return (Nut_Socket.IsConnected) ' And Me.Socket_Status
@@ -31,6 +37,16 @@ Public Class UPS_Device
         End Get
         Set(value As Integer)
             Update_Data.Interval = value
+        End Set
+    End Property
+
+    Private upsData As UPSData
+    Public Property UPS_Datas As UPSData
+        Get
+            Return upsData
+        End Get
+        Private Set(value As UPSData)
+            upsData = value
         End Set
     End Property
 
@@ -103,28 +119,13 @@ Public Class UPS_Device
     'Private NutStream As System.Net.Sockets.NetworkStream
     'Private ReaderStream As System.IO.StreamReader
     'Private WriterStream As System.IO.StreamWriter
-    'Private ShutdownStatus As Boolean = False
     'Private Follow_FSD As Boolean = False
     'Private Unknown_UPS_Name As Boolean = False
     'Private Invalid_Data As Boolean = False
     'Private Invalid_Auth_Data As Boolean = False
 
 #Region "Properties"
-    Private upsData As UPSData
-    Public Property UPS_Datas As UPSData
-        Get
-            Return upsData
-        End Get
-        Private Set(value As UPSData)
-            upsData = value
-        End Set
-    End Property
 
-    Public ReadOnly Property Name As String
-        Get
-            Return Nut_Config.UPSName
-        End Get
-    End Property
 #End Region
 
     ' Public Event Unknown_UPS()
@@ -139,8 +140,14 @@ Public Class UPS_Device
     Public Event ConnectionError(innerException As Exception)
     Public Event EncounteredNUTException(ex As NutException, sender As Object)
     Public Event New_Retry()
-    Public Event Shutdown_Condition()
-    Public Event Stop_Shutdown()
+    ' Public Event Shutdown_Condition()
+    ' Public Event Stop_Shutdown()
+
+    ''' <summary>
+    ''' Raise an event when a status code is added to the UPS that wasn't there before.
+    ''' </summary>
+    ''' <param name="newStatuses">The bitmask of status flags that are currently set on the UPS.</param>
+    Public Event StatusesChanged(sender As UPS_Device, newStatuses As UPS_States)
 
     Public Sub New(ByRef Nut_Config As Nut_Parameter, ByRef LogFile As Logger, pollInterval As Integer)
         Me.LogFile = LogFile
@@ -291,6 +298,8 @@ Public Class UPS_Device
         Return freshData
     End Function
 
+    Private oldStatusBitmask As Integer
+
     Public Sub Retrieve_UPS_Datas() Handles Update_Data.Tick ' As UPSData
         LogFile.LogTracing("Enter Retrieve_UPS_Datas", LogLvl.LOG_DEBUG, Me)
         Try
@@ -304,6 +313,7 @@ Public Class UPS_Device
                 '            UPS_Datas = GetUPSProductInfo()
                 '    End Select
                 'End With
+
                 With UPS_Datas.UPS_Value
                     .Batt_Charge = Double.Parse(GetUPSVar("battery.charge", 255), ciClone)
                     .Batt_Voltage = Double.Parse(GetUPSVar("battery.voltage", 12), ciClone)
@@ -312,7 +322,7 @@ Public Class UPS_Device
                     .Input_Voltage = Double.Parse(GetUPSVar("input.voltage", 220), ciClone)
                     .Output_Voltage = Double.Parse(GetUPSVar("output.voltage", .Input_Voltage), ciClone)
                     .Load = Double.Parse(GetUPSVar("ups.load", 100), ciClone)
-                    UPS_rt_Status = GetUPSVar("ups.status", "OL")
+                    UPS_rt_Status = GetUPSVar("ups.status")
                     .Output_Power = Double.Parse((GetUPSVar("ups.realpower.nominal", 0)), ciClone)
                     If .Output_Power = 0 Then
                         .Output_Power = Double.Parse((GetUPSVar("ups.power.nominal", 0)), ciClone)
@@ -344,70 +354,26 @@ Public Class UPS_Device
                         Dim BattInstantCurrent = (.Output_Voltage * .Load) / (.Batt_Voltage * 100)
                         .Batt_Runtime = Math.Floor(.Batt_Capacity * 0.6 * .Batt_Charge * (1 - PowerDivider) * 3600 / (BattInstantCurrent * 100))
                     End If
-                    Dim StatusArr = UPS_rt_Status.Trim().Split(" ")
-                    .UPS_Status = 0
-                    For Each State In StatusArr
-                        Select Case State
-                            Case "OL"
-                                LogFile.LogTracing("UPS is On Line", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.OL
-                            'If Not Update_Nut.Interval = Me.Delay Then
-                            '    Update_Nut.Stop()
-                            '    Update_Nut.Interval = Me.Delay
-                            '    Update_Nut.Start()
-                            'End If
-                            'If ShutdownStatus Then
-                            '    LogFile.LogTracing("Stop condition Canceled", LogLvl.LOG_NOTICE, Me, WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_SHUT_STOP))
-                            '    ShutdownStatus = False
-                            '    RaiseEvent Stop_Shutdown()
-                            'End If
-                            Case "OB"
-                                LogFile.LogTracing("UPS is On Battery", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.OB
-                            'If Update_Nut.Interval = Me.Delay Then
-                            '    Update_Nut.Stop()
-                            '    Update_Nut.Interval = If((Math.Floor(Me.Delay / 5) < 1000), 1000, Math.Floor(Me.Delay / 5))
-                            '    Update_Nut.Start()
-                            'End If
-                            'If ((Me.BattCh <= Me.Low_Batt Or Me.BattRuntime <= Me.Backup_Limit) And Not ShutdownStatus) Then
-                            '    LogFile.LogTracing("Stop condition reached", LogLvl.LOG_NOTICE, Me, WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_SHUT_START))
-                            '    RaiseEvent Shutdown_Condition()
-                            '    ShutdownStatus = True
-                            'End If
-                            Case "LB", "HB"
-                                LogFile.LogTracing("High/Low Battery on UPS", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.LBHB
-                            Case "CHRG"
-                                LogFile.LogTracing("Battery is Charging on UPS", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.CHRG
-                            Case "DISCHRG"
-                                LogFile.LogTracing("Battery is Discharging on UPS", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.DISCHRG
-                            Case "FSD"
-                                LogFile.LogTracing("Stop condition imposed by the NUT server", LogLvl.LOG_NOTICE, Me, WinNUT_Globals.StrLog.Item(AppResxStr.STR_LOG_NUT_FSD))
-                                .UPS_Status = .UPS_Status Or UPS_States.FSD
-                                RaiseEvent Shutdown_Condition()
-                            'ShutdownStatus = True
-                            Case "BYPASS"
-                                LogFile.LogTracing("UPS bypass circuit is active - no battery protection is available", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.BYPASS
-                            Case "CAL"
-                                LogFile.LogTracing("UPS is currently performing runtime calibration (on battery)", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.CAL
-                            Case "OFF"
-                                LogFile.LogTracing("UPS is offline and is not supplying power to the load", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.OFF
-                            Case "OVER"
-                                LogFile.LogTracing("UPS is overloaded", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.OVER
-                            Case "TRIM"
-                                LogFile.LogTracing("UPS is trimming incoming voltage", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.TRIM
-                            Case "BOOST"
-                                LogFile.LogTracing("UPS is boosting incoming voltage", LogLvl.LOG_NOTICE, Me)
-                                .UPS_Status = .UPS_Status Or UPS_States.BOOST
-                        End Select
-                    Next
+
+                    ' Prepare the status string for Enum parsing by replacing spaces with commas.
+                    UPS_rt_Status = UPS_rt_Status.Replace(" ", ",")
+                    Try
+                        .UPS_Status = [Enum].Parse(GetType(UPS_States), UPS_rt_Status)
+                    Catch ex As ArgumentException
+                        LogFile.LogTracing("Likely encountered an unknown/invalid UPS status. Using previous status." &
+                                           vbNewLine & ex.Message, LogLvl.LOG_ERROR, Me)
+                    End Try
+
+                    ' Get the difference between the old and new statuses, and filter only for active ones.
+                    Dim statusDiff = (oldStatusBitmask Xor .UPS_Status) And .UPS_Status
+
+                    If statusDiff = 0 Then
+                        LogFile.LogTracing("UPS statuses have not changed since last update, skipping.", LogLvl.LOG_DEBUG, Me)
+                    Else
+                        LogFile.LogTracing("UPS statuses have CHANGED, updating...", LogLvl.LOG_NOTICE, Me)
+                        oldStatusBitmask = .UPS_Status
+                        RaiseEvent StatusesChanged(Me, statusDiff)
+                    End If
                 End With
                 RaiseEvent DataUpdated()
             End If
@@ -419,7 +385,6 @@ Public Class UPS_Device
             'Me.Disconnect(True)
             'Enter_Reconnect_Process(Excep, "Error When Retrieve_UPS_Data : ")
         End Try
-        ' Return Me.UPSData
     End Sub
 
     Private Const MAX_VAR_RETRIES = 3

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -53,11 +53,7 @@ Public Class UPS_Device
 #End Region
     Private Const CosPhi As Double = 0.6
     ' How many milliseconds to wait before the Reconnect routine tries again.
-#If DEBUG Then
     Private Const DEFAULT_RECONNECT_WAIT_MS As Double = 5000
-#Else
-    Private Const DEFAULT_RECONNECT_WAIT_MS As Double = 30000
-#End If
 
     Private WithEvents Update_Data As New Timer
     'Private Nut_Conn As Nut_Comm
@@ -169,7 +165,7 @@ Public Class UPS_Device
         'End With
     End Sub
 
-    Public Sub Connect_UPS()
+    Public Sub Connect_UPS(Optional retryOnConnFailure = False)
         LogFile.LogTracing("Beginning connection: " & Nut_Config.ToString(), LogLvl.LOG_DEBUG, Me)
 
         Try
@@ -185,6 +181,10 @@ Public Class UPS_Device
         Catch ex As Exception
             RaiseEvent ConnectionError(Me, ex)
 
+            If retryOnConnFailure Then
+                LogFile.LogTracing("Reconnection Process Started", LogLvl.LOG_NOTICE, Me)
+                Reconnect_Nut.Start()
+            End If
         End Try
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -137,7 +137,7 @@ Public Class UPS_Device
     ' Notify of an unexpectedly lost connection (??)
     Public Event Lost_Connect()
     ' Error encountered when trying to connect.
-    Public Event ConnectionError(innerException As Exception)
+    Public Event ConnectionError(sender As UPS_Device, innerException As Exception)
     Public Event EncounteredNUTException(ex As NutException, sender As Object)
     Public Event New_Retry()
     ' Public Event Shutdown_Condition()
@@ -183,7 +183,7 @@ Public Class UPS_Device
             RaiseEvent EncounteredNUTException(ex, Me)
 
         Catch ex As Exception
-            RaiseEvent ConnectionError(ex)
+            RaiseEvent ConnectionError(Me, ex)
 
         End Try
     End Sub

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -174,8 +174,6 @@ Public Class UPS_Device
 
         Try
             Nut_Socket.Connect()
-            LogFile.LogTracing("TCP Socket Created", LogLvl.LOG_NOTICE, Me)
-
             ' If Nut_Socket.ExistsOnServer(Nut_Config.UPSName) Then
             UPS_Datas = GetUPSProductInfo()
             Update_Data.Start()
@@ -370,7 +368,8 @@ Public Class UPS_Device
                     If statusDiff = 0 Then
                         LogFile.LogTracing("UPS statuses have not changed since last update, skipping.", LogLvl.LOG_DEBUG, Me)
                     Else
-                        LogFile.LogTracing("UPS statuses have CHANGED, updating...", LogLvl.LOG_NOTICE, Me)
+                        LogFile.LogTracing("UPS statuses have CHANGED...", LogLvl.LOG_NOTICE, Me)
+                        LogFile.LogTracing("Current statuses: " & UPS_rt_Status, LogLvl.LOG_NOTICE, Me)
                         oldStatusBitmask = .UPS_Status
                         RaiseEvent StatusesChanged(Me, statusDiff)
                     End If

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -47,51 +47,6 @@ Public Module WinNUT_Globals
         GitHubURL = My.Application.Info.Trademark
         Copyright = My.Application.Info.Copyright
         IsConnected = False
-
-        'Add Main Gui's Strings
-        'StrLog.Insert(AppResxStr.STR_MAIN_OLDINI_RENAMED, Resources.Frm_Main_Str_01)
-        'StrLog.Insert(AppResxStr.STR_MAIN_OLDINI, Resources.Frm_Main_Str_02)
-        'StrLog.Insert(AppResxStr.STR_MAIN_RECONNECT, Resources.Frm_Main_Str_03)
-        'StrLog.Insert(AppResxStr.STR_MAIN_RETRY, Resources.Frm_Main_Str_04)
-        'StrLog.Insert(AppResxStr.STR_MAIN_NOTCONN, Resources.Frm_Main_Str_05)
-        'StrLog.Insert(AppResxStr.STR_MAIN_CONN, Resources.Frm_Main_Str_06)
-        'StrLog.Insert(AppResxStr.STR_MAIN_OL, Resources.Frm_Main_Str_07)
-        'StrLog.Insert(AppResxStr.STR_MAIN_OB, Resources.Frm_Main_Str_08)
-        'StrLog.Insert(AppResxStr.STR_MAIN_LOWBAT, Resources.Frm_Main_Str_09)
-        'StrLog.Insert(AppResxStr.STR_MAIN_BATOK, Resources.Frm_Main_Str_10)
-        'StrLog.Insert(AppResxStr.STR_MAIN_UNKNOWN_UPS, Resources.Frm_Main_Str_11)
-        'StrLog.Insert(AppResxStr.STR_MAIN_LOSTCONNECT, Resources.Frm_Main_Str_12)
-        'StrLog.Insert(AppResxStr.STR_MAIN_INVALIDLOGIN, Resources.Frm_Main_Str_13)
-        'StrLog.Insert(AppResxStr.STR_MAIN_EXITSLEEP, Resources.Frm_Main_Str_14)
-        'StrLog.Insert(AppResxStr.STR_MAIN_GOTOSLEEP, Resources.Frm_Main_Str_15)
-
-        'Add Update Gui's Strings
-        'StrLog.Insert(AppResxStr.STR_UP_AVAIL, Resources.Frm_Update_Str_01)
-        'StrLog.Insert(AppResxStr.STR_UP_SHOW, Resources.Frm_Update_Str_02)
-        'StrLog.Insert(AppResxStr.STR_UP_HIDE, Resources.Frm_Update_Str_03)
-        'StrLog.Insert(AppResxStr.STR_UP_UPMSG, Resources.Frm_Update_Str_04)
-        'StrLog.Insert(AppResxStr.STR_UP_DOWNFROM, Resources.Frm_Update_Str_05)
-
-        'Add Shutdown Gui's Strings
-        'StrLog.Insert(AppResxStr.STR_SHUT_STAT, Resources.Frm_Shutdown_Str_01)
-
-        'Add App Event's Strings 
-        'StrLog.Insert(AppResxStr.STR_APP_SHUT, Resources.App_Event_Str_01)
-
-        'Add Log's Strings
-        'StrLog.Insert(AppResxStr.STR_LOG_PREFS, Resources.Log_Str_01)
-        'StrLog.Insert(AppResxStr.STR_LOG_CONNECTED, Resources.Log_Str_02)
-        'StrLog.Insert(AppResxStr.STR_LOG_CON_FAILED, Resources.Log_Str_03)
-        'StrLog.Insert(AppResxStr.STR_LOG_CON_RETRY, Resources.Log_Str_04)
-        'StrLog.Insert(AppResxStr.STR_LOG_LOGOFF, Resources.Log_Str_05)
-        'StrLog.Insert(AppResxStr.STR_LOG_NEW_RETRY, Resources.Log_Str_06)
-        'StrLog.Insert(AppResxStr.STR_LOG_STOP_RETRY, Resources.Log_Str_07)
-        'StrLog.Insert(AppResxStr.STR_LOG_SHUT_START, Resources.Log_Str_08)
-        'StrLog.Insert(AppResxStr.STR_LOG_SHUT_STOP, Resources.Log_Str_09)
-        'StrLog.Insert(AppResxStr.STR_LOG_NO_UPDATE, Resources.Log_Str_10)
-        'StrLog.Insert(AppResxStr.STR_LOG_UPDATE, Resources.Log_Str_11)
-        'StrLog.Insert(AppResxStr.STR_LOG_NUT_FSD, Resources.Log_Str_12)
-
         LogFile = New Logger(False, LogLvl.LOG_DEBUG)
     End Sub
 


### PR DESCRIPTION
It looks like the stop action system was disabled during the client library changes. I've reactivated it.
I've also redone how UPS statuses are updated and processed, in the hopes of making program execution more efficient and bug-Closes #27 