### PR TITLE
Fix List_Var_Gui error

### DIFF
--- a/WinNUT_V2/WinNUT-Client/List_Var_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/List_Var_Gui.vb
@@ -11,7 +11,16 @@ Imports WinNUT_Client_Common
 
 Public Class List_Var_Gui
     Private List_Var_Datas As List(Of UPS_List_Datas)
+    Private UPSDevice As UPS_Device
     Private UPS_Name = WinNUT.UPS_Device.Nut_Config.UPSName
+
+    Public Sub New(upsDev As UPS_Device)
+        ' This call is required by the designer.
+        InitializeComponent()
+
+        ' Add any initialization after the InitializeComponent() call.
+        UPSDevice = upsDev
+    End Sub
 
     Private Sub List_Var_Gui_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         LogFile.LogTracing("Load List Var Gui", LogLvl.LOG_DEBUG, Me)
@@ -22,10 +31,13 @@ Public Class List_Var_Gui
     End Sub
 
     Private Sub PopulateTreeView()
-        Dim action As Action
         LogFile.LogTracing("Populate TreeView", LogLvl.LOG_DEBUG, Me)
+        Dim action As Action
+
         Try
+            UPSDevice.IsUpdatingData = False
             List_Var_Datas = WinNUT.UPS_Device.GetUPS_ListVar()
+            UPSDevice.IsUpdatingData = True
         Catch ex As Exception
             ' TODO: Internationalize?
             MessageBox.Show("Error encountered trying to get variables from the UPS: " & vbNewLine & ex.Message, "Error Encountered")

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -1006,9 +1006,8 @@ Public Class WinNUT
 
     Private Sub Menu_UPS_Var_Click(sender As Object, e As EventArgs) Handles Menu_UPS_Var.Click
         LogFile.LogTracing("Open List Var Gui", LogLvl.LOG_DEBUG, Me)
-        List_Var_Gui.Activate()
-        List_Var_Gui.Visible = True
-        HasFocus = False
+        Dim lvgForm = New List_Var_Gui(UPS_Device)
+        lvgForm.Show()
     End Sub
 
     Public Sub Update_InstantLog(sender As Object) Handles LogFile.NewData

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -40,6 +40,16 @@ Public Class UPS_Device
         End Set
     End Property
 
+    Public Property IsUpdatingData As Boolean
+        Get
+            Return Update_Data.Enabled
+        End Get
+        Set(value As Boolean)
+            LogFile.LogTracing("UPS device updating status is now [" & value & "]", LogLvl.LOG_NOTICE, Me)
+            Update_Data.Enabled = value
+        End Set
+    End Property
+
     Private upsData As UPSData
     Public Property UPS_Datas As UPSData
         Get
@@ -303,15 +313,8 @@ Public Class UPS_Device
         Try
             Dim UPS_rt_Status As String
             Dim InputA As Double
-            ' LogFile.LogTracing("Enter Retrieve_UPS_Data", LogLvl.LOG_DEBUG, Me)
-            If IsConnected Then
-                'With UPS_Datas
-                '    Select Case "Unknown"
-                '        Case .Mfr, .Model, .Serial, .Firmware
-                '            UPS_Datas = GetUPSProductInfo()
-                '    End Select
-                'End With
 
+            If IsConnected Then
                 With UPS_Datas.UPS_Value
                     .Batt_Charge = Double.Parse(GetUPSVar("battery.charge", 255), ciClone)
                     .Batt_Voltage = Double.Parse(GetUPSVar("battery.voltage", 12), ciClone)


### PR DESCRIPTION
List_Var_Gui has been throwing an error, because the list query method stopped parsing a response before it was complete, resulting in multiple queries running at once and creating an exception.

Closes #45 