### PR TITLE
Attempting to finally solve data directory oddities

### DIFF
--- a/WinNUT_V2/WinNUT-Client_Common/Logger.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Logger.vb
@@ -129,7 +129,7 @@ Public Class Logger
             Next
         End If
 
-        LogFile.WriteLine(String.Empty)
+        LogFile.WriteLine("==== Begin Live Log ====")
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client_Common/Logger.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Logger.vb
@@ -7,23 +7,38 @@
 '
 ' This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY
 
+Imports System.Globalization
 Imports System.IO
 
 Public Class Logger
 #Region "Constants/Shared"
-    Private Shared ReadOnly BASE_FILE_NAME = ProgramName ' "WinNUT-CLient"
     Private Const LOG_FILE_CREATION_SCHEDULE = Logging.LogFileCreationScheduleOption.Daily
-    ' The LogFileCreationScheduleOption doesn't present the string format of what it uses
-    Private Const LOG_FILE_DATESTRING = "yyyy-MM-dd"
+
+#If DEBUG Then
+    Private Shared ReadOnly DEFAULT_DATETIMEFORMAT = DateTimeFormatInfo.InvariantInfo
+#Else
+    Private Shared ReadOnly DEFAULT_DATETIMEFORMAT = DateTimeFormatInfo.CurrentInfo
+#End If
+
+
     ' The subfolder that will contain logs.
-    Public Const LOG_SUBFOLDER = "\Logs\"
+    Public Const LOG_SUBFOLDER = "Logs"
+
+    Private Shared ReadOnly BASE_FILE_NAME = ProgramName
+    Private ReadOnly TEventCache As New TraceEventCache()
 #End Region
 
+#Region "Private/backing values"
+
     Private LogFile As Logging.FileLogTraceListener
-    Private ReadOnly TEventCache As New TraceEventCache()
-    Public LogLevelValue As LogLvl
     Private L_CurrentLogData As String
     Private LastEventsList As New List(Of Object)
+    Private _DateTimeFormatInfo As DateTimeFormatInfo = DEFAULT_DATETIMEFORMAT
+
+#End Region
+
+    Public LogLevelValue As LogLvl
+
     Public Event NewData(sender As Object)
 
 #Region "Properties"
@@ -77,6 +92,16 @@ Public Class Logger
         End Get
     End Property
 
+    Public Property DateTimeFormatInfo As DateTimeFormatInfo
+        Get
+            Return _DateTimeFormatInfo
+        End Get
+        Set(value As DateTimeFormatInfo)
+            _DateTimeFormatInfo = value
+        End Set
+    End Property
+
+
 #End Region
 
     Public Sub New(LogLevel As LogLvl)
@@ -89,11 +114,22 @@ Public Class Logger
             .Append = True,
             .AutoFlush = True,
             .LogFileCreationSchedule = LOG_FILE_CREATION_SCHEDULE,
-            .CustomLocation = baseDataFolder & LOG_SUBFOLDER,
+            .CustomLocation = Path.Combine(baseDataFolder, LOG_SUBFOLDER),
             .Location = Logging.LogFileLocation.Custom
         }
 
-        LogTracing("Log file is initialized at " & LogFile.FullLogFileName, LogLvl.LOG_NOTICE, Me)
+        LogTracing(String.Format("{0} {1} Log file init", LongProgramName, ProgramVersion), LogLvl.LOG_NOTICE, Me)
+
+        If LastEventsList.Count > 0 Then
+            ' Fill new file with the LastEventsList buffer
+            LogFile.WriteLine("==== History of " & LastEventsList.Count & " previous events ====")
+
+            For index As Integer = 0 To LastEventsList.Count - 1
+                LogFile.WriteLine(String.Format("[{0}] {1}", index + 1, LastEventsList(index)))
+            Next
+        End If
+
+        LogFile.WriteLine(String.Empty)
     End Sub
 
     ''' <summary>
@@ -132,17 +168,7 @@ Public Class Logger
     ''' <param name="sender">What generated this message.</param>
     ''' <param name="LogToDisplay">A user-friendly, translated string to be shown.</param>
     Public Sub LogTracing(message As String, LvlError As LogLvl, sender As Object, Optional LogToDisplay As String = Nothing)
-        Dim Pid = TEventCache.ProcessId
-        Dim SenderName
-        ' Handle a null sender
-        If sender Is Nothing Then
-            SenderName = "Nothing"
-        Else
-            SenderName = sender.GetType.Name
-        End If
-
-        Dim EventTime = Now.ToLocalTime
-        Dim FinalMsg = EventTime & " Pid: " & Pid & " " & SenderName & " : " & message
+        Dim FinalMsg = FormatLogLine(message, LvlError, sender)
 
         ' Always write log messages to the attached debug messages window.
 #If DEBUG Then
@@ -166,4 +192,15 @@ Public Class Logger
             RaiseEvent NewData(sender)
         End If
     End Sub
+
+    Private Function FormatLogLine(message As String, logLvl As LogLvl, Optional sender As Object = Nothing)
+        Dim Pid = TEventCache.ProcessId
+        Dim SenderName = "Nothing"
+
+        If sender IsNot Nothing Then
+            SenderName = sender.GetType.Name
+        End If
+
+        Return String.Format("{0} [{1}, {2}]: {3}", Date.Now.ToString(_DateTimeFormatInfo), Pid, SenderName, message)
+    End Function
 End Class

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -12,7 +12,6 @@ Imports System.IO
 Public Module WinNUT_Globals
 
 #Region "Constants/Shareds"
-    ' What path we'd like to keep our data in.
 
 #If DEBUG Then
     ' If debugging, keep any generated data next to the debug executable.
@@ -23,31 +22,26 @@ Public Module WinNUT_Globals
 #End If
 
     Private ReadOnly FALLBACK_DATA_PATH = Path.GetTempPath() & ProgramName
-#End Region
 
-    Public LongProgramName As String
-    Public ProgramName As String
-    Public ProgramVersion As String
-    Public ShortProgramVersion As String
-    Public GitHubURL As String
-    Public Copyright As String
-    Public IsConnected As Boolean
+    Public ReadOnly ProgramName = My.Application.Info.ProductName
+    Public ReadOnly LongProgramName = My.Application.Info.Description
+    Public ReadOnly ProgramVersion = Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString
+    Public ReadOnly ShortProgramVersion = ProgramVersion.Substring(0, ProgramVersion.IndexOf(".", ProgramVersion.IndexOf(".") + 1))
+    Public ReadOnly GitHubURL = My.Application.Info.Trademark
+    Public ReadOnly Copyright = My.Application.Info.Copyright
+
+    Public IsConnected = False
     Public ApplicationData As String
-    Public WithEvents LogFile As Logger
+    Public WithEvents LogFile As Logger = New Logger(LogLvl.LOG_DEBUG)
     Public AppIcon As Dictionary(Of Integer, Drawing.Icon)
     Public StrLog As New List(Of String)
 
+#End Region
+
+
+
     Public Sub Init_Globals()
         ApplicationData = GetAppDirectory(DESIRED_DATA_PATH)
-        LogFile = New Logger(LogLvl.LOG_DEBUG)
-
-        LongProgramName = My.Application.Info.Description
-        ProgramName = My.Application.Info.ProductName
-        ProgramVersion = Reflection.Assembly.GetEntryAssembly().GetName().Version.ToString
-        ShortProgramVersion = ProgramVersion.Substring(0, ProgramVersion.IndexOf(".", ProgramVersion.IndexOf(".") + 1))
-        GitHubURL = My.Application.Info.Trademark
-        Copyright = My.Application.Info.Copyright
-        IsConnected = False
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -15,13 +15,13 @@ Public Module WinNUT_Globals
 
 #If DEBUG Then
     ' If debugging, keep any generated data next to the debug executable.
-    Private ReadOnly DESIRED_DATA_PATH As String = Path.Combine(Environment.CurrentDirectory, "Data")
+    Private ReadOnly DESIRED_DATA_PATH As String = Path.Combine(Environment.CurrentDirectory)
 #Else
-        Private ReadOnly DESIRED_DATA_PATH As String = Path.Combine(Environment.GetFolderPath(
-                Environment.SpecialFolder.ApplicationData), "\WinNUT-Client")
+        Private ReadOnly DESIRED_DATA_PATH As String = Environment.GetFolderPath(
+                Environment.SpecialFolder.ApplicationData))
 #End If
 
-    Private ReadOnly FALLBACK_DATA_PATH = Path.GetTempPath() & ProgramName
+    Private ReadOnly FALLBACK_DATA_PATH = Path.GetTempPath()
 
     Public ReadOnly ProgramName = My.Application.Info.ProductName
     Public ReadOnly LongProgramName = My.Application.Info.Description
@@ -45,12 +45,14 @@ Public Module WinNUT_Globals
     End Sub
 
     ''' <summary>
-    ''' Do everything possible to find a safe place to write to. If the requested option is unavailable, we fall back
-    ''' to the temporary directory for the current user.
+    ''' Do everything possible to find a safe place to write to, with the <see cref="ProgramName"/> appended to it. If
+    ''' the requested option is unavailable, we fall back to the temporary directory for the current user.
     ''' </summary>
-    ''' <param name="requestedDir">The requested directory.</param>
+    ''' <param name="requestedDir">The requested directory, with <see cref="ProgramName"/> appended to it.</param>
     ''' <returns>The best possible option available as a writable data directory.</returns>
     Private Function GetAppDirectory(requestedDir As String) As String
+        requestedDir = Path.Combine(requestedDir, ProgramName)
+
         Try
             Directory.CreateDirectory(requestedDir)
             LogFile.LogTracing("Successfully created or opened requested data directory for WinNUT." &

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -24,6 +24,7 @@ Public Module WinNUT_Globals
 #End If
 
     Private ReadOnly FALLBACK_DATA_PATH = Path.GetTempPath()
+    Private ReadOnly DATA_DIRECTORY_NAME = "WinNut-Client"
 
     Public ReadOnly ProgramName = My.Application.Info.ProductName
     Public ReadOnly LongProgramName = My.Application.Info.Description

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -14,9 +14,11 @@ Public Module WinNUT_Globals
 #Region "Constants/Shareds"
 
 #If DEBUG Then
+    Public ReadOnly IsDebugBuild = True
     ' If debugging, keep any generated data next to the debug executable.
     Private ReadOnly DESIRED_DATA_PATH As String = Path.Combine(Environment.CurrentDirectory)
 #Else
+        Public ReadOnly IsDebugBuild = False
         Private ReadOnly DESIRED_DATA_PATH As String = Environment.GetFolderPath(
                 Environment.SpecialFolder.ApplicationData))
 #End If

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -54,7 +54,7 @@ Public Module WinNUT_Globals
     ''' <param name="requestedDir">The requested directory, with <see cref="ProgramName"/> appended to it.</param>
     ''' <returns>The best possible option available as a writable data directory.</returns>
     Private Function GetAppDirectory(requestedDir As String) As String
-        requestedDir = Path.Combine(requestedDir, ProgramName)
+        requestedDir = Path.Combine(requestedDir, DATA_DIRECTORY_NAME)
 
         Try
             Directory.CreateDirectory(requestedDir)

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -59,6 +59,8 @@ Public Module WinNUT_Globals
     Private Function GetAppDirectory(requestedDir As String) As String
         Try
             Directory.CreateDirectory(requestedDir)
+            LogFile.LogTracing("Successfully created or opened requested data directory for WinNUT." &
+                               vbNewLine & "requestedDir: " & requestedDir, LogLvl.LOG_DEBUG, Nothing)
             Return requestedDir
 
         Catch ex As Exception


### PR DESCRIPTION
Judging from my Debugging output folder, it looks like generating the application's data directory has been broken since after November 11. Not quite sure what commit did it, but here's a summary of what's in this PR:

- General reorganization of the `WinNUT_Globals` Module.
  - Altered some constants to be more consistent, made shortcut properties and general static strings defined within the module itself.
  - As a result, the Init_Globals function is one line.
  - This calls the new GetAppDirectory function. It returns the best directory for storing application data (currently Logs only), starting with the specified string as the directory wanted. If that fails (i.e debug build in a read-only directory, or appdata directory is not available for some reason) then we'll use the user's default temp directory.
- Logger improvements
  -  Standardize datetime format
  - Print some output when initializing the log
  - Broke out line formatting
  - Fixed data directory naming and location

- Should close #61.
  - See also #49, #19 