### PR TITLE
Improve connection loss handling

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -346,6 +346,24 @@ Public Class WinNUT
         End If
     End Sub
 
+    Private Sub UPS_Lostconnect() Handles UPS_Device.Lost_Connect
+        LogFile.LogTracing("Notify user of lost connection", LogLvl.LOG_ERROR, Me,
+            String.Format(StrLog.Item(AppResxStr.STR_MAIN_LOSTCONNECT), UPS_Device.Nut_Config.Host, UPS_Device.Nut_Config.Port))
+        ' UPSDisconnect()
+
+        ReInitDisplayValues()
+        If UPS_Device.Nut_Config.AutoReconnect And UPS_Retry <= UPS_MaxRetry Then
+            ActualAppIconIdx = AppIconIdx.IDX_ICO_RETRY
+        Else
+            ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
+        End If
+
+        UpdateIcon_NotifyIcon()
+        RaiseEvent UpdateNotifyIconStr("Lost Connect", Nothing)
+        RaiseEvent UpdateBatteryState("Lost Connect")
+        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
+    End Sub
+
     ''' <summary>
     ''' Perform final actions to wrap up a disconnected UPS.
     ''' </summary>
@@ -585,24 +603,6 @@ Public Class WinNUT
         About_Gui.Activate()
         About_Gui.Visible = True
         HasFocus = False
-    End Sub
-
-    Private Sub UPS_Lostconnect() Handles UPS_Device.Lost_Connect
-        LogFile.LogTracing("Notify user of lost connection", LogLvl.LOG_ERROR, Me,
-            String.Format(StrLog.Item(AppResxStr.STR_MAIN_LOSTCONNECT), UPS_Device.Nut_Config.Host, UPS_Device.Nut_Config.Port))
-        ' UPSDisconnect()
-
-        'ReInitDisplayValues()
-        If UPS_Device.Nut_Config.AutoReconnect And UPS_Retry <= UPS_MaxRetry Then
-            ActualAppIconIdx = AppIconIdx.IDX_ICO_RETRY
-        Else
-            ActualAppIconIdx = AppIconIdx.IDX_ICO_OFFLINE
-        End If
-
-        UpdateIcon_NotifyIcon()
-        RaiseEvent UpdateNotifyIconStr("Lost Connect", Nothing)
-        RaiseEvent UpdateBatteryState("Lost Connect")
-        LogFile.LogTracing("Update Icon", LogLvl.LOG_DEBUG, Me)
     End Sub
 
     Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -188,7 +188,8 @@ Public Class Nut_Socket
     ''' </summary>
     ''' <param name="Query_Msg">The query to be sent to the server, within specifications of the NUT protocol.</param>
     ''' <returns>The full <see cref="Transaction"/> of this function call.</returns>
-    ''' <exception cref="InvalidOperationException">Thrown when calling this function while disconnected.</exception>"
+    ''' <exception cref="InvalidOperationException">Thrown when calling this function while disconnected, or another
+    ''' call is in progress.</exception>
     ''' <exception cref="NutException">Thrown when the NUT server returns an error or unexpected response.</exception>
     Function Query_Data(Query_Msg As String) As Transaction
         Dim Response As NUTResponse
@@ -196,21 +197,17 @@ Public Class Nut_Socket
         Dim finalTransaction As Transaction
 
         If streamInUse Then
-            LogFile.LogTracing("Attempted to query " & Query_Msg & " while using the stream.", LogLvl.LOG_ERROR, Me)
-            Return Nothing
+            Throw New InvalidOperationException("Attempted to query " & Query_Msg & " while stream is in use.")
         End If
 
-        streamInUse = True
-
         If ConnectionStatus Then
-            ' LogFile.LogTracing("Query: " & Query_Msg, LogLvl.LOG_DEBUG, Me)
+            streamInUse = True
+
             WriterStream.WriteLine(Query_Msg & vbCr)
             WriterStream.Flush()
-
             DataResult = Trim(ReaderStream.ReadLine())
-            ' LogFile.LogTracing(vbTab & "Response: " & DataResult, LogLvl.LOG_DEBUG, Me)
+
             streamInUse = False
-            ' LogFile.LogTracing("Done processing response for query " & Query_Msg, LogLvl.LOG_DEBUG, Me)
 
             Response = EnumResponse(DataResult)
             finalTransaction = New Transaction(Query_Msg, DataResult, Response)

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -203,12 +203,16 @@ Public Class Nut_Socket
         If ConnectionStatus Then
             streamInUse = True
 
-            WriterStream.WriteLine(Query_Msg & vbCr)
-            WriterStream.Flush()
+            Try
+                WriterStream.WriteLine(Query_Msg & vbCr)
+                WriterStream.Flush()
+            Catch
+                Throw
+            Finally
+                streamInUse = False
+            End Try
+
             DataResult = Trim(ReaderStream.ReadLine())
-
-            streamInUse = False
-
             Response = EnumResponse(DataResult)
             finalTransaction = New Transaction(Query_Msg, DataResult, Response)
 


### PR DESCRIPTION
Closes #63 

A few issues have been brought up:

- The WinNUT UI is left in an inconsistent state when the connection to a NUT server is unexpectedly lost.
- The `streamInUse` latch variable was left locked when the connection was broken, resulting in future queries failing.