### PR TITLE
Define UPS_States values as pow of 2 to fix state change detection

### DIFF
--- a/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
@@ -101,18 +101,18 @@ End Enum
 
 <Flags()>
 Public Enum UPS_States
-    None
-    OL
-    OB
-    LB
-    HB
-    CHRG
-    DISCHRG
-    FSD
-    BYPASS
-    CAL
-    OFF
-    OVER
-    TRIM
-    BOOST
+    None = 0
+    OL = 1 << 0
+    OB = 1 << 1
+    LB = 1 << 2
+    HB = 1 << 3
+    CHRG = 1 << 4
+    DISCHRG = 1 << 5
+    FSD = 1 << 6
+    BYPASS = 1 << 7
+    CAL = 1 << 8
+    OFF = 1 << 9
+    OVER = 1 << 10
+    TRIM = 1 << 11
+    BOOST = 1 << 12
 End Enum


### PR DESCRIPTION
The existing state detection logic relies on bitwise operations to compare old and new state and to extract the changed state flags. However it's fundamentally broken due to UPS_States enum not using the power of 2 values. Bitwise logic produces invalid states change set because of that.

I discovered it while I was trying to make this client follow FSD signal from the server. But it never detects the change for FSD state. The only case when it starts the shutdown procedure is if you connect to the server which is already in FSD state.