### PR TITLE
Error Reporting & Exception Catching Refactor

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT-client.vbproj
+++ b/WinNUT_V2/WinNUT-Client/WinNUT-client.vbproj
@@ -396,10 +396,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.1.2</Version>
+      <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>13.0.1</Version>
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -86,12 +86,6 @@ Public Class WinNUT
     Private Event RequestConnect()
 
     Private Sub WinNUT_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        ' Make sure we have an app directory to write to.
-        ' SetupAppDirectory()
-
-        AddHandler Microsoft.Win32.SystemEvents.PowerModeChanged, AddressOf SystemEvents_PowerModeChanged
-        AddHandler RequestConnect, AddressOf UPS_Connect
-
         'Add Main Gui's Strings
         StrLog.Insert(AppResxStr.STR_MAIN_OLDINI_RENAMED, My.Resources.Frm_Main_Str_01)
         StrLog.Insert(AppResxStr.STR_MAIN_OLDINI, My.Resources.Frm_Main_Str_02)
@@ -272,6 +266,9 @@ Public Class WinNUT
             Update_Frm.Visible = True
             HasFocus = False
         End If
+
+        AddHandler Microsoft.Win32.SystemEvents.PowerModeChanged, AddressOf SystemEvents_PowerModeChanged
+        AddHandler RequestConnect, AddressOf UPS_Connect
 
         LogFile.LogTracing(String.Format("{0} v{1} completed initialization.", My.Application.Info.ProductName, My.Application.Info.Version),
                            LogLvl.LOG_NOTICE, Me)
@@ -837,7 +834,7 @@ Public Class WinNUT
         ' Setup logging preferences
         If Arr_Reg_Key.Item("UseLogFile") Then
             LogFile.LogLevelValue = Arr_Reg_Key.Item("Log Level")
-            LogFile.InitializeLogFile(ApplicationData)
+            LogFile.InitializeLogFile(ApplicationDataPath)
         ElseIf LogFile.IsWritingToFile Then
             LogFile.DeleteLogFile()
         End If

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -297,6 +297,7 @@ Public Class WinNUT
                                        Arr_Reg_Key.Item("AutoReconnect"))
 
         UPS_Device = New UPS_Device(Nut_Config, LogFile, Arr_Reg_Key.Item("Delay"))
+        AddHandler UPS_Device.EncounteredNUTException, AddressOf HandleNUTException
         UPS_Device.Connect_UPS(retryOnConnFailure)
     End Sub
 
@@ -331,15 +332,16 @@ Public Class WinNUT
     End Sub
 
     ''' <summary>
-    ''' Prepare application for and handle disconnecting from the UPS.
+    ''' Prepare application for and initiate disconnecting from the UPS.
     ''' </summary>
-    Private Sub UPSDisconnect() ' Handles UPS_Device.Disconnected
-        ' LogFile.LogTracing("Running Client disconnect subroutine.", LogLvl.LOG_DEBUG, Me)
+    Private Sub UPSDisconnect()
+        LogFile.LogTracing("Running Client disconnect subroutine.", LogLvl.LOG_DEBUG, Me)
 
         If UPS_Device IsNot Nothing Then
             UPS_Device.Disconnect(True)
+            RemoveHandler UPS_Device.EncounteredNUTException, AddressOf HandleNUTException
         Else
-            LogFile.LogTracing("Attempted to disconnect when UPS_Device is Nothing.", LogLvl.LOG_DEBUG, Me)
+            LogFile.LogTracing("Attempted to disconnect when UPS_Device is Nothing.", LogLvl.LOG_ERROR, Me)
         End If
     End Sub
 
@@ -415,18 +417,14 @@ Public Class WinNUT
             NotifyIcon.Visible = True
             e.Cancel = True
         Else
-            ' TODO: Common shutdown subroutine? --v
             LogFile.LogTracing("Init Disconnecting Before Close WinNut", LogLvl.LOG_DEBUG, Me)
-            RemoveHandler Microsoft.Win32.SystemEvents.PowerModeChanged, AddressOf SystemEvents_PowerModeChanged
             UPSDisconnect()
-            LogFile.LogTracing("WinNut Is now Closed", LogLvl.LOG_DEBUG, Me)
-            End
         End If
     End Sub
 
     Private Sub Menu_Quit_Click_1(sender As Object, e As EventArgs) Handles Menu_Quit.Click
         LogFile.LogTracing("Close WinNut From Menu Quit", LogLvl.LOG_DEBUG, Me)
-        End
+        Application.Exit()
     End Sub
 
     Private Sub Menu_Settings_Click(sender As Object, e As EventArgs) Handles Menu_Settings.Click
@@ -439,7 +437,7 @@ Public Class WinNUT
 
     Private Sub Menu_Sys_Exit_Click(sender As Object, e As EventArgs) Handles Menu_Sys_Exit.Click
         LogFile.LogTracing("Close WinNut From Systray", LogLvl.LOG_DEBUG, Me)
-        End
+        Application.Exit()
     End Sub
 
     Private Sub Menu_Sys_Settings_Click(sender As Object, e As EventArgs) Handles Menu_Sys_Settings.Click
@@ -572,11 +570,12 @@ Public Class WinNUT
         LogFile.LogTracing("Battery Status => " & Status, LogLvl.LOG_DEBUG, Me)
     End Sub
 
-    Sub HandleNUTException(ex As NutException, sender As Object) Handles UPS_Device.EncounteredNUTException
+    Private Sub HandleNUTException(sender As UPS_Device, ex As NutException)
         If ex.LastTransaction.ResponseType = NUTResponse.UNKNOWNUPS Then
             Event_Unknown_UPS()
         End If
 
+        LogFile.LogTracing("NUT protocol error encoutnered:" + vbNewLine + ex.ToString(), LogLvl.LOG_NOTICE, sender)
     End Sub
 
     Public Sub Event_Unknown_UPS() ' Handles UPS_Device.Unknown_UPS


### PR DESCRIPTION
Per #79 and #80:

Another issue like #49 , some thrown exceptions aren't being caught by the bug report generator. More work is needed in that area.

In addition, ~~certain~~ Synology NUT servers allow a client to LOGIN successfully, but will then reply ACCESS-DENIED to a LOGOUT command. I don't think this should be happening, but regardless, we're not catching a protocol exception and allowing it to crash the program. Need to make sure we're handling protocol exceptions appropriately.

## Summary of changes

- More reorganization in WinNUT_Globals.vb. Renaming some variables for clarity.
- Updated dependencies
- Refactor error report generation. Attempts to account for more error conditions and ensure a report can be generated.
- Various improvements to protocol code, focusing on the Login subroutine.
- Additional small tweaks to error report generation; corrected output formatting and try to standardize times and locale.
- Additional compatibility with Synology NUT server quirk when the client is not in the allowed clients list (Synology-only feature)