### PR TITLE
Re-enable retry connection on first start

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -401,7 +401,7 @@ Public Class WinNUT
         ' Begin auto-connecting if user indicated they wanted it. (Note: Will hang form because we don't do threading yet)
         If Arr_Reg_Key.Item("AutoReconnect") Then
             LogFile.LogTracing("Auto-connecting to UPS on startup.", LogLvl.LOG_NOTICE, Me)
-            UPS_Connect()
+            UPS_Connect(True)
         End If
 
         LogFile.LogTracing("Completed WinNUT_Shown", LogLvl.LOG_DEBUG, Me)


### PR DESCRIPTION
I had disabled the auto-retry functionality at start because the program hangs as it tries to connect. We'll need to address multithreaded app functionality to truly fix this. In the mean time, WinNUT will now try to automatically reconnect at start when connection issues are encountered.

Closes #104 