### PR TITLE
Standard Exception logging subroutine, variable error handling, misc. bugfixes

### DIFF
--- a/WinNUT_V2/WinNUT-Client/About_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/About_Gui.vb
@@ -11,7 +11,7 @@ Imports WinNUT_Client_Common
 
 Public Class About_Gui
     Private Sub About_Gui_Load(sender As Object, e As EventArgs) Handles MyBase.Load
-        Lbl_ProgNameVersion.Text = LongProgramName & vbNewLine & "Version " & ProgramVersion
+        Lbl_ProgNameVersion.Text = ProgramName & vbNewLine & "Version " & ProgramVersion
         Lbl_Copyright_2019.Text = Replace(Copyright, "©", vbNewLine & "©")
         LkLbl_Github.Text = GitHubURL
         Icon = WinNUT.Icon

--- a/WinNUT_V2/WinNUT-Client/App.config
+++ b/WinNUT_V2/WinNUT-Client/App.config
@@ -83,7 +83,7 @@
     <value>0</value>
    </setting>
    <setting name="UP_LastCheck" serializeAs="String">
-    <value/>
+    <value />
    </setting>
    <setting name="PW_BattChrgFloor" serializeAs="String">
     <value>30</value>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
@@ -1742,9 +1742,10 @@ Accepted value: Numeric value from 0 to 100.</source>
           <target state="translated">除錯</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</source>
-          <target state="translated">UPS 資料更新頻率 (預設值 5 秒)。範圍：1-60 秒。</target>
+          <source>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</source>
+          <target state="needs-review-translation">UPS 資料更新頻率 (預設值 5 秒)。範圍：1-60 秒。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Label3.ImeMode" translate="no" extype="System.Windows.Forms.ImeMode, System.Windows.Forms" xml:space="preserve">
           <source>NoControl</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
@@ -1235,9 +1235,10 @@
           <target state="final">17, 17</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</source>
-          <target state="translated">Zeit zwischen jeder Aktualisierung der USV-Daten (Standard = 5).Wertebereich: Numerischer Wert von 1 bis 60 Sekunden.</target>
+          <source>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</source>
+          <target state="needs-review-translation">Zeit zwischen jeder Aktualisierung der USV-Daten (Standard = 5).Wertebereich: Numerischer Wert von 1 bis 60 Sekunden.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
@@ -1238,10 +1238,11 @@ inférieur à</target>
           <target state="final">17, 17</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</source>
-          <target state="final">Temps entre chaque mise à jour des données UPS (par défaut = 5).
+          <source>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</source>
+          <target state="needs-review-translation">Temps entre chaque mise à jour des données UPS (par défaut = 5).
 Valeur acceptée: valeur numérique de 1 à 60 secondes.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
@@ -1274,10 +1274,11 @@ along with this program. If not, see https://www.gnu.org/licenses/.</target>
           <target state="final">12</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</source>
-          <target state="final">Время между обновлениями данных ИБП (по умолчанию = 5).
+          <source>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</source>
+          <target state="needs-review-translation">Время между обновлениями данных ИБП (по умолчанию = 5).
 Число от 1 до 60 секунд.</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
@@ -1438,10 +1438,11 @@ Accepted value: Numeric value from 0 to 999.</source>
           <target state="final">12</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</source>
-          <target state="final">每次更新UPS数据之间的时间（默认= 5）。
+          <source>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</source>
+          <target state="needs-review-translation">每次更新UPS数据之间的时间（默认= 5）。
 接受值：1到60秒之间的数值。</target>
+          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>

--- a/WinNUT_V2/WinNUT-Client/My Project/Resources.Designer.vb
+++ b/WinNUT_V2/WinNUT-Client/My Project/Resources.Designer.vb
@@ -689,6 +689,24 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Old preferences were not detected in your system..
+        '''</summary>
+        Public ReadOnly Property ManageOldPrefsToolstripMenuItem_Disabled_TooltipText() As String
+            Get
+                Return ResourceManager.GetString("ManageOldPrefsToolstripMenuItem_Disabled_TooltipText", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Old preferences detected. Click to run the import wizard..
+        '''</summary>
+        Public ReadOnly Property ManageOldPrefsToolstripMenuItem_Enabled_TooltipText() As String
+            Get
+                Return ResourceManager.GetString("ManageOldPrefsToolstripMenuItem_Enabled_TooltipText", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized resource of type System.Drawing.Bitmap.
         '''</summary>
         Public ReadOnly Property regedit_exe_14_100_0() As System.Drawing.Bitmap

--- a/WinNUT_V2/WinNUT-Client/My Project/Resources.Designer.vb
+++ b/WinNUT_V2/WinNUT-Client/My Project/Resources.Designer.vb
@@ -794,6 +794,15 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Unavailable.
+        '''</summary>
+        Public ReadOnly Property VariableUnavailable() As String
+            Get
+                Return ResourceManager.GetString("VariableUnavailable", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized resource of type System.Drawing.Bitmap.
         '''</summary>
         Public ReadOnly Property ViewLogFile_24x24() As System.Drawing.Bitmap

--- a/WinNUT_V2/WinNUT-Client/My Project/Resources.resx
+++ b/WinNUT_V2/WinNUT-Client/My Project/Resources.resx
@@ -367,6 +367,10 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
   <data name="ups_104x104" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\ups_104x104.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="VariableUnavailable" xml:space="preserve">
+    <value>Unavailable</value>
+    <comment>Indicate that a variable is unavailable</comment>
+  </data>
   <data name="ViewLogFile_24x24" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\ViewLogFile_24x24.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/WinNUT_V2/WinNUT-Client/My Project/Resources.resx
+++ b/WinNUT_V2/WinNUT-Client/My Project/Resources.resx
@@ -321,6 +321,14 @@ Cancel to Save Msi and Install Later</value>
   <data name="Log_Str_12" xml:space="preserve">
     <value>Stop condition imposed by the NUT server</value>
   </data>
+  <data name="ManageOldPrefsToolstripMenuItem_Disabled_TooltipText" xml:space="preserve">
+    <value>Old preferences were not detected in your system.</value>
+    <comment>Similar to _Enabled tooltip, except that the preferences were not detected.</comment>
+  </data>
+  <data name="ManageOldPrefsToolstripMenuItem_Enabled_TooltipText" xml:space="preserve">
+    <value>Old preferences detected. Click to run the import wizard.</value>
+    <comment>Tooltip of the "manage old prefs" menu item, explaining that the old preferences were detected and that clicking will open the wizard dialog.</comment>
+  </data>
   <data name="regedit_exe_14_100_0" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>

--- a/WinNUT_V2/WinNUT-Client/My Project/Settings.Designer.vb
+++ b/WinNUT_V2/WinNUT-Client/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.7.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
@@ -117,6 +117,26 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="Tb_Pwd_Nut.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 191</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Tb_Pwd_Nut.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
+    <value>*</value>
+  </data>
+  <data name="Tb_Pwd_Nut.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_Pwd_Nut.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <metadata name="Pref_TlTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="Tb_Pwd_Nut.ToolTip" xml:space="preserve">
+    <value>NUT server login password</value>
+  </data>
   <data name="&gt;&gt;Tb_Pwd_Nut.Name" xml:space="preserve">
     <value>Tb_Pwd_Nut</value>
   </data>
@@ -128,6 +148,18 @@
   </data>
   <data name="&gt;&gt;Tb_Pwd_Nut.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="Tb_Login_Nut.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 161</value>
+  </data>
+  <data name="Tb_Login_Nut.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_Login_Nut.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="Tb_Login_Nut.ToolTip" xml:space="preserve">
+    <value>NUT server connection identifier</value>
   </data>
   <data name="&gt;&gt;Tb_Login_Nut.Name" xml:space="preserve">
     <value>Tb_Login_Nut</value>
@@ -141,6 +173,25 @@
   <data name="&gt;&gt;Tb_Login_Nut.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 132</value>
+  </data>
+  <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>300, 13</value>
+  </data>
+  <data name="Label3.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="Label3.Text" xml:space="preserve">
+    <value>Login credentials to the Nut server (leave blank if not required)</value>
+  </data>
   <data name="&gt;&gt;Label3.Name" xml:space="preserve">
     <value>Label3</value>
   </data>
@@ -152,6 +203,24 @@
   </data>
   <data name="&gt;&gt;Label3.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 192</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="Lbl_Pwd_Nut.Text" xml:space="preserve">
+    <value>Password</value>
   </data>
   <data name="&gt;&gt;Lbl_Pwd_Nut.Name" xml:space="preserve">
     <value>Lbl_Pwd_Nut</value>
@@ -165,6 +234,24 @@
   <data name="&gt;&gt;Lbl_Pwd_Nut.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="Lbl_Login_Nut.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Login_Nut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="Lbl_Login_Nut.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 162</value>
+  </data>
+  <data name="Lbl_Login_Nut.Size" type="System.Drawing.Size, System.Drawing">
+    <value>33, 13</value>
+  </data>
+  <data name="Lbl_Login_Nut.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="Lbl_Login_Nut.Text" xml:space="preserve">
+    <value>Login</value>
+  </data>
   <data name="&gt;&gt;Lbl_Login_Nut.Name" xml:space="preserve">
     <value>Lbl_Login_Nut</value>
   </data>
@@ -176,6 +263,19 @@
   </data>
   <data name="&gt;&gt;Lbl_Login_Nut.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="Tb_Delay_Com.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 101</value>
+  </data>
+  <data name="Tb_Delay_Com.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_Delay_Com.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
+    <value>Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</value>
   </data>
   <data name="&gt;&gt;Tb_Delay_Com.Name" xml:space="preserve">
     <value>Tb_Delay_Com</value>
@@ -189,6 +289,19 @@
   <data name="&gt;&gt;Tb_Delay_Com.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="Tb_UPS_Name.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 71</value>
+  </data>
+  <data name="Tb_UPS_Name.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_UPS_Name.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
+    <value>UPS name to monitor.
+Accepted Value: Name of the UPS configured in the Nut server.</value>
+  </data>
   <data name="&gt;&gt;Tb_UPS_Name.Name" xml:space="preserve">
     <value>Tb_UPS_Name</value>
   </data>
@@ -200,6 +313,22 @@
   </data>
   <data name="&gt;&gt;Tb_UPS_Name.ZOrder" xml:space="preserve">
     <value>6</value>
+  </data>
+  <data name="Tb_Port.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 41</value>
+  </data>
+  <data name="Tb_Port.MaxLength" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="Tb_Port.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_Port.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="Tb_Port.ToolTip" xml:space="preserve">
+    <value>Nut Server Port Number (default = 3493).
+Accepted value: Numeric value from 1 to 65535.</value>
   </data>
   <data name="&gt;&gt;Tb_Port.Name" xml:space="preserve">
     <value>Tb_Port</value>
@@ -213,6 +342,19 @@
   <data name="&gt;&gt;Tb_Port.ZOrder" xml:space="preserve">
     <value>7</value>
   </data>
+  <data name="Tb_Server_IP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 11</value>
+  </data>
+  <data name="Tb_Server_IP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 20</value>
+  </data>
+  <data name="Tb_Server_IP.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="Tb_Server_IP.ToolTip" xml:space="preserve">
+    <value>Nut server address.
+Accepted value: IPV4 / IPV6 / FQDN address.</value>
+  </data>
   <data name="&gt;&gt;Tb_Server_IP.Name" xml:space="preserve">
     <value>Tb_Server_IP</value>
   </data>
@@ -224,6 +366,30 @@
   </data>
   <data name="&gt;&gt;Tb_Server_IP.ZOrder" xml:space="preserve">
     <value>8</value>
+  </data>
+  <data name="Cb_Reconnect.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Cb_Reconnect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>66, 213</value>
+  </data>
+  <data name="Cb_Reconnect.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>250, 0</value>
+  </data>
+  <data name="Cb_Reconnect.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
+    <value>Yes</value>
+  </data>
+  <data name="Cb_Reconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>250, 17</value>
+  </data>
+  <data name="Cb_Reconnect.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="Cb_Reconnect.Text" xml:space="preserve">
+    <value>Re-establish connection</value>
+  </data>
+  <data name="Cb_Reconnect.ToolTip" xml:space="preserve">
+    <value>Activate automatic connection / reconnection</value>
   </data>
   <data name="&gt;&gt;Cb_Reconnect.Name" xml:space="preserve">
     <value>Cb_Reconnect</value>
@@ -237,6 +403,21 @@
   <data name="&gt;&gt;Cb_Reconnect.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
+  <data name="Lbl_Delay_Com.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Delay_Com.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 102</value>
+  </data>
+  <data name="Lbl_Delay_Com.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 13</value>
+  </data>
+  <data name="Lbl_Delay_Com.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="Lbl_Delay_Com.Text" xml:space="preserve">
+    <value>Polling Interval</value>
+  </data>
   <data name="&gt;&gt;Lbl_Delay_Com.Name" xml:space="preserve">
     <value>Lbl_Delay_Com</value>
   </data>
@@ -248,6 +429,21 @@
   </data>
   <data name="&gt;&gt;Lbl_Delay_Com.ZOrder" xml:space="preserve">
     <value>10</value>
+  </data>
+  <data name="Lbl_Name_UPS.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Name_UPS.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 72</value>
+  </data>
+  <data name="Lbl_Name_UPS.Size" type="System.Drawing.Size, System.Drawing">
+    <value>60, 13</value>
+  </data>
+  <data name="Lbl_Name_UPS.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="Lbl_Name_UPS.Text" xml:space="preserve">
+    <value>UPS Name</value>
   </data>
   <data name="&gt;&gt;Lbl_Name_UPS.Name" xml:space="preserve">
     <value>Lbl_Name_UPS</value>
@@ -261,6 +457,21 @@
   <data name="&gt;&gt;Lbl_Name_UPS.ZOrder" xml:space="preserve">
     <value>11</value>
   </data>
+  <data name="Lbl_Port.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Port.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 42</value>
+  </data>
+  <data name="Lbl_Port.Size" type="System.Drawing.Size, System.Drawing">
+    <value>52, 13</value>
+  </data>
+  <data name="Lbl_Port.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="Lbl_Port.Text" xml:space="preserve">
+    <value>NUT Port</value>
+  </data>
   <data name="&gt;&gt;Lbl_Port.Name" xml:space="preserve">
     <value>Lbl_Port</value>
   </data>
@@ -272,6 +483,24 @@
   </data>
   <data name="&gt;&gt;Lbl_Port.ZOrder" xml:space="preserve">
     <value>12</value>
+  </data>
+  <data name="Lbl_Server_IP.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="Lbl_Server_IP.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 12</value>
+  </data>
+  <data name="Lbl_Server_IP.Size" type="System.Drawing.Size, System.Drawing">
+    <value>53, 13</value>
+  </data>
+  <data name="Lbl_Server_IP.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="Lbl_Server_IP.Text" xml:space="preserve">
+    <value>NUT host</value>
+  </data>
+  <data name="Lbl_Server_IP.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
   </data>
   <data name="&gt;&gt;Lbl_Server_IP.Name" xml:space="preserve">
     <value>Lbl_Server_IP</value>
@@ -285,18 +514,15 @@
   <data name="&gt;&gt;Lbl_Server_IP.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="Tab_Connexion.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Tab_Connexion.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 3, 3</value>
   </data>
   <data name="Tab_Connexion.Size" type="System.Drawing.Size, System.Drawing">
     <value>322, 234</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Tab_Connexion.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
@@ -333,9 +559,6 @@
   <data name="Cbx_Freq_Input.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
   </data>
-  <metadata name="Pref_TlTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="Cbx_Freq_Input.ToolTip" xml:space="preserve">
     <value>Sets the input frequency if not supplied by the UPS.</value>
   </data>
@@ -806,841 +1029,6 @@ Accepted value: Numeric value from 0 to 999.</value>
   <data name="&gt;&gt;Tab_Calibrage.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;Cbx_LogLevel.Name" xml:space="preserve">
-    <value>Cbx_LogLevel</value>
-  </data>
-  <data name="&gt;&gt;Cbx_LogLevel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cbx_LogLevel.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Cbx_LogLevel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Btn_DeleteLog.Name" xml:space="preserve">
-    <value>Btn_DeleteLog</value>
-  </data>
-  <data name="&gt;&gt;Btn_DeleteLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Btn_DeleteLog.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Btn_DeleteLog.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;Btn_ViewLog.Name" xml:space="preserve">
-    <value>Btn_ViewLog</value>
-  </data>
-  <data name="&gt;&gt;Btn_ViewLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Btn_ViewLog.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Btn_ViewLog.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;Lbl_LevelLog.Name" xml:space="preserve">
-    <value>Lbl_LevelLog</value>
-  </data>
-  <data name="&gt;&gt;Lbl_LevelLog.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_LevelLog.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Lbl_LevelLog.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;CB_Use_Logfile.Name" xml:space="preserve">
-    <value>CB_Use_Logfile</value>
-  </data>
-  <data name="&gt;&gt;CB_Use_Logfile.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Use_Logfile.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;CB_Use_Logfile.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_W_Win.Name" xml:space="preserve">
-    <value>CB_Start_W_Win</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_W_Win.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_W_Win.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_W_Win.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;CB_Close_Tray.Name" xml:space="preserve">
-    <value>CB_Close_Tray</value>
-  </data>
-  <data name="&gt;&gt;CB_Close_Tray.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Close_Tray.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;CB_Close_Tray.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_Mini.Name" xml:space="preserve">
-    <value>CB_Start_Mini</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_Mini.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_Mini.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;CB_Start_Mini.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;CB_Systray.Name" xml:space="preserve">
-    <value>CB_Systray</value>
-  </data>
-  <data name="&gt;&gt;CB_Systray.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Systray.Parent" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;CB_Systray.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Tab_Miscellanous.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Miscellanous.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Miscellanous.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Tab_Miscellanous.Text" xml:space="preserve">
-    <value>Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Name" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;CB_Follow_FSD.Name" xml:space="preserve">
-    <value>CB_Follow_FSD</value>
-  </data>
-  <data name="&gt;&gt;CB_Follow_FSD.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CB_Follow_FSD.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;CB_Follow_FSD.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Percent.Name" xml:space="preserve">
-    <value>Lbl_Percent</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Percent.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Percent.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Percent.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;Tb_GraceTime.Name" xml:space="preserve">
-    <value>Tb_GraceTime</value>
-  </data>
-  <data name="&gt;&gt;Tb_GraceTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_GraceTime.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tb_GraceTime.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;Cb_ExtendTime.Name" xml:space="preserve">
-    <value>Cb_ExtendTime</value>
-  </data>
-  <data name="&gt;&gt;Cb_ExtendTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cb_ExtendTime.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Cb_ExtendTime.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Stop.Name" xml:space="preserve">
-    <value>Tb_Delay_Stop</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Stop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Stop.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Stop.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;Cbx_TypeStop.Name" xml:space="preserve">
-    <value>Cbx_TypeStop</value>
-  </data>
-  <data name="&gt;&gt;Cbx_TypeStop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cbx_TypeStop.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Cbx_TypeStop.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;Cb_ImmediateStop.Name" xml:space="preserve">
-    <value>Cb_ImmediateStop</value>
-  </data>
-  <data name="&gt;&gt;Cb_ImmediateStop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cb_ImmediateStop.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Cb_ImmediateStop.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Time.Name" xml:space="preserve">
-    <value>Tb_BattLimit_Time</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Time.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Time.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Time.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Load.Name" xml:space="preserve">
-    <value>Tb_BattLimit_Load</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Load.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Load.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tb_BattLimit_Load.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;Lbl_GraceTime.Name" xml:space="preserve">
-    <value>Lbl_GraceTime</value>
-  </data>
-  <data name="&gt;&gt;Lbl_GraceTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_GraceTime.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_GraceTime.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Stop.Name" xml:space="preserve">
-    <value>Lbl_Delay_Stop</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Stop.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Stop.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Stop.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;Lbl_StopType.Name" xml:space="preserve">
-    <value>Lbl_StopType</value>
-  </data>
-  <data name="&gt;&gt;Lbl_StopType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_StopType.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_StopType.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Time.Name" xml:space="preserve">
-    <value>Lbl_BattLimit_Time</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Time.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Time.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Time.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Load.Name" xml:space="preserve">
-    <value>Lbl_BattLimit_Load</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Load.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Load.Parent" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattLimit_Load.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="Tab_Shutdown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Shutdown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="Tab_Shutdown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Shutdown.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="Tab_Shutdown.Text" xml:space="preserve">
-    <value>Shutdown Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Name" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Branch_Update.Name" xml:space="preserve">
-    <value>Cbx_Branch_Update</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Branch_Update.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Branch_Update.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Branch_Update.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Delay_Verif.Name" xml:space="preserve">
-    <value>Cbx_Delay_Verif</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Delay_Verif.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Delay_Verif.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Cbx_Delay_Verif.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Branch_Update.Name" xml:space="preserve">
-    <value>Lbl_Branch_Update</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Branch_Update.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Branch_Update.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Branch_Update.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Verif.Name" xml:space="preserve">
-    <value>Lbl_Delay_Verif</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Verif.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Verif.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Verif.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;Cb_Update_At_Start.Name" xml:space="preserve">
-    <value>Cb_Update_At_Start</value>
-  </data>
-  <data name="&gt;&gt;Cb_Update_At_Start.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cb_Update_At_Start.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Cb_Update_At_Start.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;Cb_Verify_Update.Name" xml:space="preserve">
-    <value>Cb_Verify_Update</value>
-  </data>
-  <data name="&gt;&gt;Cb_Verify_Update.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cb_Verify_Update.Parent" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Cb_Verify_Update.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Tab_Update.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Update.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Update.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="Tab_Update.Text" xml:space="preserve">
-    <value>Update</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Name" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="TabControl_Options.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
-  <data name="TabControl_Options.Size" type="System.Drawing.Size, System.Drawing">
-    <value>330, 260</value>
-  </data>
-  <data name="TabControl_Options.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Name" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Tb_Pwd_Nut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 191</value>
-  </data>
-  <data name="Tb_Pwd_Nut.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
-    <value>*</value>
-  </data>
-  <data name="Tb_Pwd_Nut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Pwd_Nut.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="Tb_Pwd_Nut.ToolTip" xml:space="preserve">
-    <value>NUT server login password</value>
-  </data>
-  <data name="&gt;&gt;Tb_Pwd_Nut.Name" xml:space="preserve">
-    <value>Tb_Pwd_Nut</value>
-  </data>
-  <data name="&gt;&gt;Tb_Pwd_Nut.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Pwd_Nut.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Pwd_Nut.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="Tb_Login_Nut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 161</value>
-  </data>
-  <data name="Tb_Login_Nut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Login_Nut.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="Tb_Login_Nut.ToolTip" xml:space="preserve">
-    <value>NUT server connection identifier</value>
-  </data>
-  <data name="&gt;&gt;Tb_Login_Nut.Name" xml:space="preserve">
-    <value>Tb_Login_Nut</value>
-  </data>
-  <data name="&gt;&gt;Tb_Login_Nut.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Login_Nut.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Login_Nut.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 132</value>
-  </data>
-  <data name="Label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>300, 13</value>
-  </data>
-  <data name="Label3.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="Label3.Text" xml:space="preserve">
-    <value>Login credentials to the Nut server (leave blank if not required)</value>
-  </data>
-  <data name="&gt;&gt;Label3.Name" xml:space="preserve">
-    <value>Label3</value>
-  </data>
-  <data name="&gt;&gt;Label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Label3.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Label3.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 192</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="Lbl_Pwd_Nut.Text" xml:space="preserve">
-    <value>Password</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Pwd_Nut.Name" xml:space="preserve">
-    <value>Lbl_Pwd_Nut</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Pwd_Nut.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Pwd_Nut.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Pwd_Nut.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="Lbl_Login_Nut.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Login_Nut.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="Lbl_Login_Nut.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 162</value>
-  </data>
-  <data name="Lbl_Login_Nut.Size" type="System.Drawing.Size, System.Drawing">
-    <value>33, 13</value>
-  </data>
-  <data name="Lbl_Login_Nut.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="Lbl_Login_Nut.Text" xml:space="preserve">
-    <value>Login</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Login_Nut.Name" xml:space="preserve">
-    <value>Lbl_Login_Nut</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Login_Nut.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Login_Nut.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Login_Nut.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Tb_Delay_Com.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 101</value>
-  </data>
-  <data name="Tb_Delay_Com.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Delay_Com.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>Time between each update of UPS data (default = 5).
-Accepted value: Numerical value from 1 to 60 seconds.</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Name" xml:space="preserve">
-    <value>Tb_Delay_Com</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="Tb_UPS_Name.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 71</value>
-  </data>
-  <data name="Tb_UPS_Name.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_UPS_Name.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
-  </data>
-  <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
-    <value>UPS name to monitor.
-Accepted Value: Name of the UPS configured in the Nut server.</value>
-  </data>
-  <data name="&gt;&gt;Tb_UPS_Name.Name" xml:space="preserve">
-    <value>Tb_UPS_Name</value>
-  </data>
-  <data name="&gt;&gt;Tb_UPS_Name.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_UPS_Name.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_UPS_Name.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="Tb_Port.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 41</value>
-  </data>
-  <data name="Tb_Port.MaxLength" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="Tb_Port.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Port.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="Tb_Port.ToolTip" xml:space="preserve">
-    <value>Nut Server Port Number (default = 3493).
-Accepted value: Numeric value from 1 to 65535.</value>
-  </data>
-  <data name="&gt;&gt;Tb_Port.Name" xml:space="preserve">
-    <value>Tb_Port</value>
-  </data>
-  <data name="&gt;&gt;Tb_Port.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Port.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Port.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="Tb_Server_IP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 11</value>
-  </data>
-  <data name="Tb_Server_IP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Server_IP.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="Tb_Server_IP.ToolTip" xml:space="preserve">
-    <value>Nut server address.
-Accepted value: IPV4 / IPV6 / FQDN address.</value>
-  </data>
-  <data name="&gt;&gt;Tb_Server_IP.Name" xml:space="preserve">
-    <value>Tb_Server_IP</value>
-  </data>
-  <data name="&gt;&gt;Tb_Server_IP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Server_IP.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Server_IP.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="Cb_Reconnect.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Cb_Reconnect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>66, 213</value>
-  </data>
-  <data name="Cb_Reconnect.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>250, 0</value>
-  </data>
-  <data name="Cb_Reconnect.RightToLeft" type="System.Windows.Forms.RightToLeft, System.Windows.Forms">
-    <value>Yes</value>
-  </data>
-  <data name="Cb_Reconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>250, 17</value>
-  </data>
-  <data name="Cb_Reconnect.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="Cb_Reconnect.Text" xml:space="preserve">
-    <value>Re-establish connection</value>
-  </data>
-  <data name="Cb_Reconnect.ToolTip" xml:space="preserve">
-    <value>Activate automatic connection / reconnection</value>
-  </data>
-  <data name="&gt;&gt;Cb_Reconnect.Name" xml:space="preserve">
-    <value>Cb_Reconnect</value>
-  </data>
-  <data name="&gt;&gt;Cb_Reconnect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Cb_Reconnect.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Cb_Reconnect.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="Lbl_Delay_Com.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Delay_Com.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 102</value>
-  </data>
-  <data name="Lbl_Delay_Com.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 13</value>
-  </data>
-  <data name="Lbl_Delay_Com.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="Lbl_Delay_Com.Text" xml:space="preserve">
-    <value>Polling Interval</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Com.Name" xml:space="preserve">
-    <value>Lbl_Delay_Com</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Com.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Com.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Delay_Com.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="Lbl_Name_UPS.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Name_UPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 72</value>
-  </data>
-  <data name="Lbl_Name_UPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 13</value>
-  </data>
-  <data name="Lbl_Name_UPS.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="Lbl_Name_UPS.Text" xml:space="preserve">
-    <value>UPS Name</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name_UPS.Name" xml:space="preserve">
-    <value>Lbl_Name_UPS</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name_UPS.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name_UPS.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name_UPS.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="Lbl_Port.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Port.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 42</value>
-  </data>
-  <data name="Lbl_Port.Size" type="System.Drawing.Size, System.Drawing">
-    <value>52, 13</value>
-  </data>
-  <data name="Lbl_Port.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="Lbl_Port.Text" xml:space="preserve">
-    <value>NUT Port</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Port.Name" xml:space="preserve">
-    <value>Lbl_Port</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Port.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Port.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Port.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="Lbl_Server_IP.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="Lbl_Server_IP.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 12</value>
-  </data>
-  <data name="Lbl_Server_IP.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
-  </data>
-  <data name="Lbl_Server_IP.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="Lbl_Server_IP.Text" xml:space="preserve">
-    <value>NUT host</value>
-  </data>
-  <data name="Lbl_Server_IP.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleCenter</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Server_IP.Name" xml:space="preserve">
-    <value>Lbl_Server_IP</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Server_IP.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Server_IP.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Server_IP.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
   <data name="Cbx_LogLevel.Items" xml:space="preserve">
     <value>Notice</value>
   </data>
@@ -1949,6 +1337,30 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
   </data>
   <data name="&gt;&gt;CB_Systray.ZOrder" xml:space="preserve">
     <value>8</value>
+  </data>
+  <data name="Tab_Miscellanous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Miscellanous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Miscellanous.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Tab_Miscellanous.Text" xml:space="preserve">
+    <value>Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Name" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="CB_Follow_FSD.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2358,6 +1770,33 @@ Accepted value: Numeric value from 0 to 100.</value>
   <data name="&gt;&gt;Lbl_BattLimit_Load.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
+  <data name="Tab_Shutdown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Shutdown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="Tab_Shutdown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Shutdown.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="Tab_Shutdown.Text" xml:space="preserve">
+    <value>Shutdown Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Name" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="Cbx_Branch_Update.Items" xml:space="preserve">
     <value>Stable</value>
   </data>
@@ -2546,6 +1985,51 @@ Accepted value: Numeric value from 0 to 100.</value>
   </data>
   <data name="&gt;&gt;Cb_Verify_Update.ZOrder" xml:space="preserve">
     <value>5</value>
+  </data>
+  <data name="Tab_Update.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Update.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Update.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="Tab_Update.Text" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Name" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="TabControl_Options.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="TabControl_Options.Size" type="System.Drawing.Size, System.Drawing">
+    <value>330, 260</value>
+  </data>
+  <data name="TabControl_Options.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Name" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="Btn_Ok.Location" type="System.Drawing.Point, System.Drawing">
     <value>105, 278</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
@@ -241,8 +241,8 @@ Public Class Pref_Gui
             LogFile.LogTracing(String.Format("Check that the value of {0} for {1} is correct.", sender.Text, sender.Name), LogLvl.LOG_DEBUG, Me)
             Select Case sender.Name
                 Case "Tb_Delay_Com"
-                    MinValue = 1
-                    MaxValue = 60
+                    MinValue = 100
+                    MaxValue = 60000
                 Case "Tb_Port"
                     MinValue = 1
                     MaxValue = 65536

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
@@ -338,10 +338,10 @@ Public Class Pref_Gui
 
     Private Sub Btn_ViewLog_Click(sender As Object, e As EventArgs) Handles Btn_ViewLog.Click
         LogFile.LogTracing("Show LogFile", LogLvl.LOG_DEBUG, Me)
-        If File.Exists(LogFile.LogFilePath) Then
+        If LogFile IsNot Nothing AndAlso File.Exists(LogFile.LogFilePath) Then
             Process.Start(LogFile.LogFilePath)
         Else
-            LogFile.LogTracing("LogFile does not exists", LogLvl.LOG_WARNING, Me)
+            LogFile.LogTracing("LogFile does not exists", LogLvl.LOG_ERROR, Me)
             Btn_ViewLog.Enabled = False
             Btn_DeleteLog.Enabled = False
         End If
@@ -368,14 +368,14 @@ Public Class Pref_Gui
     ''' Enable or disable controls to view and delete log data if it's available.
     ''' </summary>
     Private Sub SetLogControlsStatus()
-        If My.Settings.LG_LogToFile Then ' Directory.Exists(Logger.LogFolder)
+        LogFile.LogTracing("Setting LogControl statuses.", LogLvl.LOG_DEBUG, Me)
+
+        If LogFile.IsWritingToFile Then
             Btn_ViewLog.Enabled = True
             Btn_DeleteLog.Enabled = True
         Else
             Btn_ViewLog.Enabled = False
             Btn_DeleteLog.Enabled = False
         End If
-
-        LogFile.LogTracing("Setting LogControl statuses.", LogLvl.LOG_DEBUG, Me)
     End Sub
 End Class

--- a/WinNUT_V2/WinNUT-Client/WinNUT.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.resx
@@ -124,22 +124,6 @@
     <value>364, 17</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="ContextMenu_Systray.Size" type="System.Drawing.Size, System.Drawing">
-    <value>145, 110</value>
-  </data>
-  <data name="&gt;&gt;ContextMenu_Systray.Name" xml:space="preserve">
-    <value>ContextMenu_Systray</value>
-  </data>
-  <data name="&gt;&gt;ContextMenu_Systray.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="NotifyIcon.Text" xml:space="preserve">
-    <value>NotifyIcon1</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="NotifyIcon.Visible" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
   <data name="Menu_Sys_Settings.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 22</value>
   </data>
@@ -173,6 +157,22 @@
   <data name="Menu_Sys_Exit.Text" xml:space="preserve">
     <value>Exit</value>
   </data>
+  <data name="ContextMenu_Systray.Size" type="System.Drawing.Size, System.Drawing">
+    <value>145, 110</value>
+  </data>
+  <data name="&gt;&gt;ContextMenu_Systray.Name" xml:space="preserve">
+    <value>ContextMenu_Systray</value>
+  </data>
+  <data name="&gt;&gt;ContextMenu_Systray.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="NotifyIcon.Text" xml:space="preserve">
+    <value>NotifyIcon1</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="NotifyIcon.Visible" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <metadata name="Main_Menu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>248, 17</value>
   </metadata>
@@ -186,6 +186,81 @@
   <data name="Main_Menu.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>None</value>
   </data>
+  <data name="Menu_UPS_Var.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="Menu_UPS_Var.Text" xml:space="preserve">
+    <value>UPS Variable</value>
+  </data>
+  <data name="Menu_Quit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="Menu_Quit.Text" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="ManageOldPrefsToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="ManageOldPrefsToolStripMenuItem.ShortcutKeyDisplayString" xml:space="preserve">
+    <value />
+  </data>
+  <data name="ManageOldPrefsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="ManageOldPrefsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Manage Old Prefs...</value>
+  </data>
+  <data name="Menu_File.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 20</value>
+  </data>
+  <data name="Menu_File.Text" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="Menu_Reconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 22</value>
+  </data>
+  <data name="Menu_Reconnect.Text" xml:space="preserve">
+    <value>Reconnect</value>
+  </data>
+  <data name="Menu_Disconnect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>133, 22</value>
+  </data>
+  <data name="Menu_Disconnect.Text" xml:space="preserve">
+    <value>Disconnect</value>
+  </data>
+  <data name="Menu_Connection.Size" type="System.Drawing.Size, System.Drawing">
+    <value>81, 20</value>
+  </data>
+  <data name="Menu_Connection.Text" xml:space="preserve">
+    <value>Connection</value>
+  </data>
+  <data name="Menu_Settings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>61, 20</value>
+  </data>
+  <data name="Menu_Settings.Text" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="Menu_About.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 22</value>
+  </data>
+  <data name="Menu_About.Text" xml:space="preserve">
+    <value>About</value>
+  </data>
+  <data name="Menu_Help_Sep1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>141, 6</value>
+  </data>
+  <data name="Menu_Update.Size" type="System.Drawing.Size, System.Drawing">
+    <value>144, 22</value>
+  </data>
+  <data name="Menu_Update.Text" xml:space="preserve">
+    <value>Verify Update</value>
+  </data>
+  <data name="Menu_Help.Size" type="System.Drawing.Size, System.Drawing">
+    <value>44, 20</value>
+  </data>
+  <data name="Menu_Help.Text" xml:space="preserve">
+    <value>Help</value>
+  </data>
   <data name="Main_Menu.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
@@ -193,7 +268,7 @@
     <value>0, 24</value>
   </data>
   <data name="Main_Menu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>231, 24</value>
+    <value>351, 24</value>
   </data>
   <data name="Main_Menu.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -213,84 +288,6 @@
   <data name="&gt;&gt;Main_Menu.ZOrder" xml:space="preserve">
     <value>9</value>
   </data>
-  <data name="Menu_File.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 20</value>
-  </data>
-  <data name="Menu_File.Text" xml:space="preserve">
-    <value>File</value>
-  </data>
-  <data name="Menu_UPS_Var.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 22</value>
-  </data>
-  <data name="Menu_UPS_Var.Text" xml:space="preserve">
-    <value>UPS Variable</value>
-  </data>
-  <data name="Menu_Quit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 22</value>
-  </data>
-  <data name="Menu_Quit.Text" xml:space="preserve">
-    <value>Exit</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.ShortcutKeyDisplayString" xml:space="preserve">
-    <value />
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>177, 22</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Text" xml:space="preserve">
-    <value>Manage Old Prefs...</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Previous old preferences detected. Continue to begin the dialog.</value>
-  </data>
-  <data name="Menu_Connection.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 20</value>
-  </data>
-  <data name="Menu_Connection.Text" xml:space="preserve">
-    <value>Connection</value>
-  </data>
-  <data name="Menu_Reconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>133, 22</value>
-  </data>
-  <data name="Menu_Reconnect.Text" xml:space="preserve">
-    <value>Reconnect</value>
-  </data>
-  <data name="Menu_Disconnect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>133, 22</value>
-  </data>
-  <data name="Menu_Disconnect.Text" xml:space="preserve">
-    <value>Disconnect</value>
-  </data>
-  <data name="Menu_Settings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 20</value>
-  </data>
-  <data name="Menu_Settings.Text" xml:space="preserve">
-    <value>Settings</value>
-  </data>
-  <data name="Menu_Help.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 20</value>
-  </data>
-  <data name="Menu_Help.Text" xml:space="preserve">
-    <value>Help</value>
-  </data>
-  <data name="Menu_About.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 22</value>
-  </data>
-  <data name="Menu_About.Text" xml:space="preserve">
-    <value>About</value>
-  </data>
-  <data name="Menu_Help_Sep1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>141, 6</value>
-  </data>
-  <data name="Menu_Update.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 22</value>
-  </data>
-  <data name="Menu_Update.Text" xml:space="preserve">
-    <value>Verify Update</value>
-  </data>
   <metadata name="GB_Status.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -299,249 +296,6 @@
   </data>
   <data name="GB_Status.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>None</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VSerial.Name" xml:space="preserve">
-    <value>Lbl_VSerial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VSerial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VSerial.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VSerial.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VFirmware.Name" xml:space="preserve">
-    <value>Lbl_VFirmware</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VFirmware.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VFirmware.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VFirmware.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VName.Name" xml:space="preserve">
-    <value>Lbl_VName</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VName.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VName.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VMfr.Name" xml:space="preserve">
-    <value>Lbl_VMfr</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VMfr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VMfr.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VMfr.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VRTime.Name" xml:space="preserve">
-    <value>Lbl_VRTime</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VRTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VRTime.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VRTime.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOB.Name" xml:space="preserve">
-    <value>Lbl_VOB</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOB.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOB.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOLoad.Name" xml:space="preserve">
-    <value>Lbl_VOLoad</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOLoad.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOLoad.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOLoad.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VBL.Name" xml:space="preserve">
-    <value>Lbl_VBL</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VBL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VBL.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VBL.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOL.Name" xml:space="preserve">
-    <value>Lbl_VOL</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOL.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_VOL.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Firmware.Name" xml:space="preserve">
-    <value>Lbl_Firmware</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Firmware.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Firmware.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Firmware.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Serial.Name" xml:space="preserve">
-    <value>Lbl_Serial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Serial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Serial.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Serial.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name.Name" xml:space="preserve">
-    <value>Lbl_Name</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Name.ZOrder" xml:space="preserve">
-    <value>11</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Mfr.Name" xml:space="preserve">
-    <value>Lbl_Mfr</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Mfr.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Mfr.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Mfr.ZOrder" xml:space="preserve">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;Lbl_RTime.Name" xml:space="preserve">
-    <value>Lbl_RTime</value>
-  </data>
-  <data name="&gt;&gt;Lbl_RTime.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_RTime.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_RTime.ZOrder" xml:space="preserve">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BL.Name" xml:space="preserve">
-    <value>Lbl_BL</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BL.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BL.ZOrder" xml:space="preserve">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OLoad.Name" xml:space="preserve">
-    <value>Lbl_OLoad</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OLoad.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OLoad.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OLoad.ZOrder" xml:space="preserve">
-    <value>15</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OB.Name" xml:space="preserve">
-    <value>Lbl_OB</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OB.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OB.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OB.ZOrder" xml:space="preserve">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OL.Name" xml:space="preserve">
-    <value>Lbl_OL</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OL.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OL.Parent" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OL.ZOrder" xml:space="preserve">
-    <value>17</value>
-  </data>
-  <data name="GB_Status.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 27</value>
-  </data>
-  <data name="GB_Status.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>180, 320</value>
-  </data>
-  <data name="GB_Status.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>180, 320</value>
-  </data>
-  <data name="GB_Status.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 320</value>
-  </data>
-  <data name="GB_Status.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;GB_Status.Name" xml:space="preserve">
-    <value>GB_Status</value>
-  </data>
-  <data name="&gt;&gt;GB_Status.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_Status.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_Status.ZOrder" xml:space="preserve">
-    <value>7</value>
   </data>
   <data name="Lbl_VSerial.Font" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Bold</value>
@@ -1158,56 +912,38 @@
   <data name="&gt;&gt;Lbl_OL.ZOrder" xml:space="preserve">
     <value>17</value>
   </data>
+  <data name="GB_Status.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 27</value>
+  </data>
+  <data name="GB_Status.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>180, 320</value>
+  </data>
+  <data name="GB_Status.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>180, 320</value>
+  </data>
+  <data name="GB_Status.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 320</value>
+  </data>
+  <data name="GB_Status.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;GB_Status.Name" xml:space="preserve">
+    <value>GB_Status</value>
+  </data>
+  <data name="&gt;&gt;GB_Status.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_Status.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_Status.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
   <metadata name="GB_InV_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_InV_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;AG_InV.Name" xml:space="preserve">
-    <value>AG_InV</value>
-  </data>
-  <data name="&gt;&gt;AG_InV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_InV.Parent" xml:space="preserve">
-    <value>GB_InV_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_InV.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InV_Dial.Name" xml:space="preserve">
-    <value>Lbl_InV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InV_Dial.Parent" xml:space="preserve">
-    <value>GB_InV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InV_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GB_InV_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 27</value>
-  </data>
-  <data name="GB_InV_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_InV_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;GB_InV_Dial.Name" xml:space="preserve">
-    <value>GB_InV_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_InV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_InV_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_InV_Dial.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="AG_InV.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1222,7 +958,7 @@
     <value>AG_InV</value>
   </data>
   <data name="&gt;&gt;AG_InV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_InV.Parent" xml:space="preserve">
     <value>GB_InV_Dial</value>
@@ -1269,56 +1005,32 @@
   <data name="&gt;&gt;Lbl_InV_Dial.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="GB_InV_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 27</value>
+  </data>
+  <data name="GB_InV_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_InV_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;GB_InV_Dial.Name" xml:space="preserve">
+    <value>GB_InV_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_InV_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_InV_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_InV_Dial.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <metadata name="GB_OutV_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_OutV_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;AG_OutV.Name" xml:space="preserve">
-    <value>AG_OutV</value>
-  </data>
-  <data name="&gt;&gt;AG_OutV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_OutV.Parent" xml:space="preserve">
-    <value>GB_OutV_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_OutV.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OutV_Dial.Name" xml:space="preserve">
-    <value>Lbl_OutV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OutV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OutV_Dial.Parent" xml:space="preserve">
-    <value>GB_OutV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_OutV_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GB_OutV_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 27</value>
-  </data>
-  <data name="GB_OutV_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_OutV_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;GB_OutV_Dial.Name" xml:space="preserve">
-    <value>GB_OutV_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_OutV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_OutV_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_OutV_Dial.ZOrder" xml:space="preserve">
-    <value>6</value>
   </data>
   <data name="AG_OutV.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1339,7 +1051,7 @@
     <value>AG_OutV</value>
   </data>
   <data name="&gt;&gt;AG_OutV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_OutV.Parent" xml:space="preserve">
     <value>GB_OutV_Dial</value>
@@ -1386,68 +1098,32 @@
   <data name="&gt;&gt;Lbl_OutV_Dial.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="GB_OutV_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 27</value>
+  </data>
+  <data name="GB_OutV_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_OutV_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;GB_OutV_Dial.Name" xml:space="preserve">
+    <value>GB_OutV_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_OutV_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_OutV_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_OutV_Dial.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
   <metadata name="GB_BattCh_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_BattCh_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;PBox_Battery_State.Name" xml:space="preserve">
-    <value>PBox_Battery_State</value>
-  </data>
-  <data name="&gt;&gt;PBox_Battery_State.Type" xml:space="preserve">
-    <value>System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PBox_Battery_State.Parent" xml:space="preserve">
-    <value>GB_BattCh_Dial</value>
-  </data>
-  <data name="&gt;&gt;PBox_Battery_State.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattCh_Dial.Name" xml:space="preserve">
-    <value>Lbl_BattCh_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattCh_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattCh_Dial.Parent" xml:space="preserve">
-    <value>GB_BattCh_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattCh_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;AG_BattCh.Name" xml:space="preserve">
-    <value>AG_BattCh</value>
-  </data>
-  <data name="&gt;&gt;AG_BattCh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_BattCh.Parent" xml:space="preserve">
-    <value>GB_BattCh_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_BattCh.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="GB_BattCh_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 188</value>
-  </data>
-  <data name="GB_BattCh_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_BattCh_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;GB_BattCh_Dial.Name" xml:space="preserve">
-    <value>GB_BattCh_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_BattCh_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_BattCh_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_BattCh_Dial.ZOrder" xml:space="preserve">
-    <value>8</value>
   </data>
   <data name="PBox_Battery_State.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -1531,7 +1207,7 @@
     <value>AG_BattCh</value>
   </data>
   <data name="&gt;&gt;AG_BattCh.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_BattCh.Parent" xml:space="preserve">
     <value>GB_BattCh_Dial</value>
@@ -1539,56 +1215,32 @@
   <data name="&gt;&gt;AG_BattCh.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="GB_BattCh_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>200, 188</value>
+  </data>
+  <data name="GB_BattCh_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_BattCh_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;GB_BattCh_Dial.Name" xml:space="preserve">
+    <value>GB_BattCh_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_BattCh_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_BattCh_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_BattCh_Dial.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
   <metadata name="GB_Load_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_Load_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;AG_Load.Name" xml:space="preserve">
-    <value>AG_Load</value>
-  </data>
-  <data name="&gt;&gt;AG_Load.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_Load.Parent" xml:space="preserve">
-    <value>GB_Load_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_Load.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Load_Dial.Name" xml:space="preserve">
-    <value>Lbl_Load_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Load_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Load_Dial.Parent" xml:space="preserve">
-    <value>GB_Load_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_Load_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GB_Load_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>366, 188</value>
-  </data>
-  <data name="GB_Load_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_Load_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;GB_Load_Dial.Name" xml:space="preserve">
-    <value>GB_Load_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_Load_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_Load_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_Load_Dial.ZOrder" xml:space="preserve">
-    <value>5</value>
   </data>
   <data name="AG_Load.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1609,7 +1261,7 @@
     <value>AG_Load</value>
   </data>
   <data name="&gt;&gt;AG_Load.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_Load.Parent" xml:space="preserve">
     <value>GB_Load_Dial</value>
@@ -1656,56 +1308,32 @@
   <data name="&gt;&gt;Lbl_Load_Dial.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="GB_Load_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>366, 188</value>
+  </data>
+  <data name="GB_Load_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_Load_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;GB_Load_Dial.Name" xml:space="preserve">
+    <value>GB_Load_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_Load_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_Load_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_Load_Dial.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <metadata name="GB_BattV_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_BattV_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;AG_BattV.Name" xml:space="preserve">
-    <value>AG_BattV</value>
-  </data>
-  <data name="&gt;&gt;AG_BattV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_BattV.Parent" xml:space="preserve">
-    <value>GB_BattV_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_BattV.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattV_Dial.Name" xml:space="preserve">
-    <value>Lbl_BattV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattV_Dial.Parent" xml:space="preserve">
-    <value>GB_BattV_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_BattV_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GB_BattV_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>532, 188</value>
-  </data>
-  <data name="GB_BattV_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_BattV_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;GB_BattV_Dial.Name" xml:space="preserve">
-    <value>GB_BattV_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_BattV_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_BattV_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_BattV_Dial.ZOrder" xml:space="preserve">
-    <value>4</value>
   </data>
   <data name="AG_BattV.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1726,7 +1354,7 @@
     <value>AG_BattV</value>
   </data>
   <data name="&gt;&gt;AG_BattV.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_BattV.Parent" xml:space="preserve">
     <value>GB_BattV_Dial</value>
@@ -1773,56 +1401,32 @@
   <data name="&gt;&gt;Lbl_BattV_Dial.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="GB_BattV_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>532, 188</value>
+  </data>
+  <data name="GB_BattV_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_BattV_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;GB_BattV_Dial.Name" xml:space="preserve">
+    <value>GB_BattV_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_BattV_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_BattV_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_BattV_Dial.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
   <metadata name="GB_InF_Dial.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="GB_InF_Dial.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
-  </data>
-  <data name="&gt;&gt;AG_InF.Name" xml:space="preserve">
-    <value>AG_InF</value>
-  </data>
-  <data name="&gt;&gt;AG_InF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;AG_InF.Parent" xml:space="preserve">
-    <value>GB_InF_Dial</value>
-  </data>
-  <data name="&gt;&gt;AG_InF.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InF_Dial.Name" xml:space="preserve">
-    <value>Lbl_InF_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InF_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InF_Dial.Parent" xml:space="preserve">
-    <value>GB_InF_Dial</value>
-  </data>
-  <data name="&gt;&gt;Lbl_InF_Dial.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="GB_InF_Dial.Location" type="System.Drawing.Point, System.Drawing">
-    <value>366, 27</value>
-  </data>
-  <data name="GB_InF_Dial.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 160</value>
-  </data>
-  <data name="GB_InF_Dial.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;GB_InF_Dial.Name" xml:space="preserve">
-    <value>GB_InF_Dial</value>
-  </data>
-  <data name="&gt;&gt;GB_InF_Dial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;GB_InF_Dial.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;GB_InF_Dial.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="AG_InF.Location" type="System.Drawing.Point, System.Drawing">
     <value>6, 26</value>
@@ -1843,7 +1447,7 @@
     <value>AG_InF</value>
   </data>
   <data name="&gt;&gt;AG_InF.Type" xml:space="preserve">
-    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8800.22772, Culture=neutral, PublicKeyToken=null</value>
+    <value>System.Windows.Forms.AGauge, AGauge, Version=2.1.8814.30445, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;AG_InF.Parent" xml:space="preserve">
     <value>GB_InF_Dial</value>
@@ -1889,6 +1493,27 @@
   </data>
   <data name="&gt;&gt;Lbl_InF_Dial.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="GB_InF_Dial.Location" type="System.Drawing.Point, System.Drawing">
+    <value>366, 27</value>
+  </data>
+  <data name="GB_InF_Dial.Size" type="System.Drawing.Size, System.Drawing">
+    <value>160, 160</value>
+  </data>
+  <data name="GB_InF_Dial.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;GB_InF_Dial.Name" xml:space="preserve">
+    <value>GB_InF_Dial</value>
+  </data>
+  <data name="&gt;&gt;GB_InF_Dial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;GB_InF_Dial.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;GB_InF_Dial.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="CB_CurrentLog.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -584,7 +584,6 @@ Public Class WinNUT
     End Sub
 
     Private Sub Event_UpdateBatteryState(Optional Reason As String = Nothing) Handles Me.UpdateBatteryState
-        Static Dim Old_Battery_Value As Integer = UPS_BattCh
         Dim Status As String = "Unknown"
         Select Case Reason
             Case Nothing, "Deconnected", "Lost Connect"
@@ -606,7 +605,6 @@ Public Class WinNUT
                     End If
                 End If
         End Select
-        Old_Battery_Value = UPS_BattCh
         LogFile.LogTracing("Battery Status => " & Status, LogLvl.LOG_DEBUG, Me)
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -133,7 +133,7 @@ Public Class WinNUT
         StrLog.Insert(AppResxStr.STR_LOG_NUT_FSD, My.Resources.Log_Str_12)
 
         'Init Systray
-        NotifyIcon.Text = LongProgramName & " - " & ShortProgramVersion
+        NotifyIcon.Text = ProgramName & " - " & ShortProgramVersion
         NotifyIcon.Visible = False
         LogFile.LogTracing("NotifyIcons Initialised", LogLvl.LOG_DEBUG, Me)
 
@@ -576,7 +576,7 @@ Public Class WinNUT
         If Me.WindowState = System.Windows.Forms.FormWindowState.Minimized And NotifyIcon.Visible = False Then
             Text = FormText
         Else
-            Text = LongProgramName
+            Text = ProgramName
         End If
         Me.FormText = FormText
 
@@ -730,6 +730,7 @@ Public Class WinNUT
             End Select
 
             ' Calculate and display estimated remaining time on battery.
+            ' TODO: overflow exception?
             Dim iSpan As TimeSpan = TimeSpan.FromSeconds(UPS_BattRuntime)
             LogFile.LogTracing("Calculated estimated remaining battery time: " & iSpan.ToString(), LogLvl.LOG_DEBUG, Me)
 
@@ -1032,6 +1033,13 @@ Public Class WinNUT
         LogFile.LogTracing("Windows going down, WinNUT will disconnect.", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
         UPSDisconnect()
 
+        ' Stub out stop action when debugging.
+#If DEBUG Then
+        If Debugger.IsAttached Then
+            LogFile.LogTracing("Aborting stopAction " & stopAction & " due to attached debugger.", LogLvl.LOG_NOTICE, Me)
+            Return
+        End If
+#Else
         Select Case stopAction
             Case 0
                 Process.Start("C:\WINDOWS\system32\Shutdown.exe", "-f -s -t 0")
@@ -1040,6 +1048,7 @@ Public Class WinNUT
             Case 2
                 Application.SetSuspendState(PowerState.Hibernate, False, True)
         End Select
+#End If
     End Sub
 
     Private Sub Menu_Update_Click(sender As Object, e As EventArgs) Handles Menu_Update.Click

--- a/WinNUT_V2/WinNUT-Client_Common/Logger.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Logger.vb
@@ -9,6 +9,7 @@
 
 Imports System.Globalization
 Imports System.IO
+Imports System.Text
 Imports Microsoft.VisualBasic.Logging
 
 Public Class Logger
@@ -129,7 +130,7 @@ Public Class Logger
             LogFile.CustomLocation = baseDataFolder
         End If
 
-        LogTracing(String.Format("{0} {1} Log file init", LongProgramName, ProgramVersion), LogLvl.LOG_NOTICE, Me)
+        LogTracing(String.Format("{0} {1} Log file init", ProgramName, ProgramVersion), LogLvl.LOG_NOTICE, Me)
 
         If LastEventsList.Count > 0 Then
             ' Fill new file with the LastEventsList buffer
@@ -202,6 +203,22 @@ Public Class Logger
             L_CurrentLogData = LogToDisplay
             RaiseEvent NewData(sender)
         End If
+    End Sub
+
+    Public Sub LogException(ex As Exception, sender As Object)
+        Dim sb As New StringBuilder
+        sb.AppendLine(ex.GetType().ToString() & " thrown in " & ex.Source)
+        sb.AppendLine("Message: " & ex.Message)
+        sb.AppendLine(ex.StackTrace)
+
+        LogTracing(sb.ToString(), LogLvl.LOG_ERROR, sender)
+
+        If ex.InnerException IsNot Nothing Then
+            LogTracing("Inner exception present:", LogLvl.LOG_ERROR, sender)
+            LogException(ex.InnerException, ex)
+        End If
+
+        LogTracing("Exception report complete.", LogLvl.LOG_NOTICE, Me)
     End Sub
 
     Private Function FormatLogLine(message As String, logLvl As LogLvl, Optional sender As Object = Nothing)

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -361,9 +361,10 @@ Public Class UPS_Device
                 End With
                 RaiseEvent DataUpdated()
             End If
-        Catch Excep As Exception
             ' Something went wrong while trying to read the data... Consider the socket broken and proceed from here.
-            LogFile.LogTracing("Something went wrong in Retrieve_UPS_Datas: " & Excep.ToString(), LogLvl.LOG_ERROR, Me)
+        Catch Excep As Exception
+            LogFile.LogTracing("Something went wrong in Retrieve_UPS_Datas:", LogLvl.LOG_ERROR, Me)
+            LogFile.LogException(Excep, Me)
             Disconnect(False, True)
             Socket_Broken()
         End Try

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -318,7 +318,7 @@ Public Class UPS_Device
                     End If
 
                     ' Handle out-of-range battery charge
-                    If .Batt_Charge > 0 AndAlso .Batt_Charge <= 100 Then
+                    If .Batt_Charge < 0 OrElse .Batt_Charge > 100 Then
                         If .Batt_Voltage > 0 Then
                             Dim nBatt = Math.Floor(.Batt_Voltage / 12)
                             .Batt_Charge = Math.Floor((.Batt_Voltage - (11.6 * nBatt)) / (0.02 * nBatt))
@@ -327,7 +327,7 @@ Public Class UPS_Device
                         End If
                     End If
 
-                    ' Handle cases of UPSs that are unable to report battery runtime or load correctly while on battery.
+                    ' Attempt to calculate battery runtime if not given by the UPS.
                     If .Batt_Runtime = -1 Then
                         If .Output_Voltage = -1 OrElse .Batt_Voltage = -1 OrElse .Batt_Capacity = -1 OrElse .Batt_Charge = -1 Then
                             LogFile.LogTracing("Unable to calculate battery runtime, missing UPS variables.", LogLvl.LOG_WARNING, Me)

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -264,7 +264,7 @@ Public Class UPS_Device
         End Try
 
         ' Other constant values for UPS calibration.
-        freshData.UPS_Value.Batt_Capacity = Double.Parse(GetUPSVar("battery.capacity", 7), INVARIANT_CULTURE)
+        freshData.UPS_Value.Batt_Capacity = Double.Parse(GetUPSVar("battery.capacity", -1), INVARIANT_CULTURE)
         Freq_Fallback = Double.Parse(GetUPSVar("output.frequency.nominal", Freq_Fallback), INVARIANT_CULTURE)
 
         LogFile.LogTracing("Completed retrieval of basic UPS product information.", LogLvl.LOG_NOTICE, Me)
@@ -280,11 +280,11 @@ Public Class UPS_Device
 
             If IsConnected Then
                 With UPS_Datas.UPS_Value
-                    .Batt_Charge = Double.Parse(GetUPSVar("battery.charge", 255), INVARIANT_CULTURE)
-                    .Batt_Voltage = Double.Parse(GetUPSVar("battery.voltage", 12), INVARIANT_CULTURE)
-                    .Batt_Runtime = Double.Parse(GetUPSVar("battery.runtime", 86400), INVARIANT_CULTURE)
+                    .Batt_Charge = Double.Parse(GetUPSVar("battery.charge", -1), INVARIANT_CULTURE)
+                    .Batt_Voltage = Double.Parse(GetUPSVar("battery.voltage", -1), INVARIANT_CULTURE)
+                    .Batt_Runtime = Double.Parse(GetUPSVar("battery.runtime", -1), INVARIANT_CULTURE)
                     .Power_Frequency = Double.Parse(GetUPSVar("input.frequency", Double.Parse(GetUPSVar("output.frequency", Freq_Fallback), INVARIANT_CULTURE)), INVARIANT_CULTURE)
-                    .Input_Voltage = Double.Parse(GetUPSVar("input.voltage", 220), INVARIANT_CULTURE)
+                    .Input_Voltage = Double.Parse(GetUPSVar("input.voltage", -1), INVARIANT_CULTURE)
                     .Output_Voltage = Double.Parse(GetUPSVar("output.voltage", .Input_Voltage), INVARIANT_CULTURE)
                     .Load = Double.Parse(GetUPSVar("ups.load", 0), INVARIANT_CULTURE)
 
@@ -317,24 +317,36 @@ Public Class UPS_Device
                         .Output_Power = parsedValue
                     End If
 
-                    ' Handle cases of UPSs that are unable to report battery runtime or load correctly while on battery.
-                    Dim PowerDivider As Double = 0.5
-                    Select Case .Load
-                        Case 76 To 100
-                            PowerDivider = 0.4
-                        Case 51 To 75
-                            PowerDivider = 0.3
-                    End Select
-
-                    If .Batt_Charge = 255 Then
-                        Dim nBatt = Math.Floor(.Batt_Voltage / 12)
-                        .Batt_Charge = Math.Floor((.Batt_Voltage - (11.6 * nBatt)) / (0.02 * nBatt))
+                    ' Handle out-of-range battery charge
+                    If .Batt_Charge > 0 AndAlso .Batt_Charge <= 100 Then
+                        If .Batt_Voltage > 0 Then
+                            Dim nBatt = Math.Floor(.Batt_Voltage / 12)
+                            .Batt_Charge = Math.Floor((.Batt_Voltage - (11.6 * nBatt)) / (0.02 * nBatt))
+                        Else
+                            LogFile.LogTracing("Unable to calculate UPS Batt_Charge: Batt_Voltage (" & .Batt_Voltage & ") out of range.", LogLvl.LOG_WARNING, Me)
+                        End If
                     End If
 
-                    If .Batt_Runtime >= 86400 Then
-                        .Load = If(.Load <> 0, .Load, 0.1)
-                        Dim BattInstantCurrent = (.Output_Voltage * .Load) / (.Batt_Voltage * 100)
-                        .Batt_Runtime = Math.Floor(.Batt_Capacity * 0.6 * .Batt_Charge * (1 - PowerDivider) * 3600 / (BattInstantCurrent * 100))
+                    ' Handle cases of UPSs that are unable to report battery runtime or load correctly while on battery.
+                    If .Batt_Runtime = -1 Then
+                        If .Output_Voltage = -1 OrElse .Batt_Voltage = -1 OrElse .Batt_Capacity = -1 OrElse .Batt_Charge = -1 Then
+                            LogFile.LogTracing("Unable to calculate battery runtime, missing UPS variables.", LogLvl.LOG_WARNING, Me)
+                            LogFile.LogTracing(String.Format("Output_Voltage: {0}, Batt_Voltage: {1}, Batt_Capacity: {2}, Batt_Charge: {3}",
+                                .Output_Voltage, .Batt_Voltage, .Batt_Capacity, .Batt_Charge), LogLvl.LOG_WARNING, Me)
+
+                        Else
+                            Dim PowerDivider As Double = 0.5
+                            Select Case .Load
+                                Case 76 To 100
+                                    PowerDivider = 0.4
+                                Case 51 To 75
+                                    PowerDivider = 0.3
+                            End Select
+
+                            .Load = If(.Load <> 0, .Load, 0.1)
+                            Dim BattInstantCurrent = (.Output_Voltage * .Load) / (.Batt_Voltage * 100)
+                            .Batt_Runtime = Math.Floor(.Batt_Capacity * 0.6 * .Batt_Charge * (1 - PowerDivider) * 3600 / (BattInstantCurrent * 100))
+                        End If
                     End If
 
                     UPS_rt_Status = GetUPSVar("ups.status", UPS_States.None)

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT_Globals.vb
@@ -12,7 +12,6 @@ Public Module WinNUT_Globals
 #Region "Constants/Shareds"
 
     Public ReadOnly ProgramName = My.Application.Info.ProductName
-    Public ReadOnly LongProgramName = My.Application.Info.Description
     Public ReadOnly ProgramVersion = My.Application.Info.Version.ToString()
     Public ReadOnly ShortProgramVersion = ProgramVersion.Substring(0, ProgramVersion.IndexOf(".", ProgramVersion.IndexOf(".") + 1))
     Public ReadOnly GitHubURL = My.Application.Info.Trademark


### PR DESCRIPTION
# Upgrade logging
There's some more room for improvement in how logs are created.
- Created `LogException` subroutine - standard method for logging Exceptions.
- Modified `UPS_Device.Retrieve_UPS_Datas` to use this subroutine for general exceptions.
- Better handling of missing log file - disable controls in Prefs GUI when true
- See also: https://github.com/nutdotnet/WinNUT-Client/issues/93

# Miscellaneous bugfixes
- Corrected update interval setting and Prefs tooltip to accurately reflect that it's given in milliseconds. Fixes validation error in the Prefs GUI with default value.
- Fixed main WinNUT titlebar being blank.
- Made _old preferences upgrade_ menu item enable and disable correctly.
- Battery and voltage variables are each set to a more obvious error value (-1) when an error occurs while querying their values, rather than a more real-looking fallback value. See also: https://github.com/nutdotnet/WinNUT-Client/issues/116
- Attempts to calculate battery charge and runtime values fail if important variables for each calculation are also missing. As a result, an error message is logged and the out of range values are left alone.

# `System.OverflowException`

[User reports](https://github.com/nutdotnet/WinNUT-Client/issues/129#issue-2111700581) an `OverflowException` was occurring where the `UPS_BattCh` double variable is cast to an Integer. It's not used for anything, so I'm removing it in the hopes that this will solve the issue.

> System.OverflowException: An arithmetic operation causes an overflow.
In the WinNUT_Client.WinNUT.Event_UpdateBatteryState(String Reason) location WinNUT_V2\WinNUT-Client\WinNUT.vb: line number 533
At WinNUT_Client.WinNUT.UPSDisconnectedEvent() location WinNUT_V2\WinNUT-Client\WinNUT.vb: line number 359
at WinNUT_Client_Common.UPS_Device.DisconnectedEventHandler.Invoke()
at WinNUT_Client_Common.UPS_Device.Disconnect(Boolean cancelReconnect, Boolean forceful) at location WinNUT_V2\WinNUT-Client_Common\UPS_Device.vb: Line number 185
at WinNUT_Client_Common.UPS_Device.Retrieve_UPS_Datas(Object sender, EventArgs e) location WinNUT_V2\WinNUT-Client_Common\UPS_ Device.vb: Line number 366
at System.Windows.Forms.Timer.OnTick(EventArgs)
at System.Windows.Forms.Timer.TimerNativeWindow.WndProc(Message& m)
at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)

https://github.com/nutdotnet/WinNUT-Client/pull/131/commits/43ac206f7e67224ec2c79f7e47c8f1b83c6e23e5

# `System.NullReferenceException`

In addition, the [user found](https://github.com/nutdotnet/WinNUT-Client/issues/129#issuecomment-1933285529) another bug where the View and Delete log controls were enabled (logging option enabled) while the log file was not present. More protections have been added to prevent this problem.

> System.NullReferenceException: The object reference is not set to an instance of the object.
   At WinNUT_Client_Common.Logger.get_LogFilePath() location D:aWinNUT-ClientWinNUT-ClientWinNUT_V2WinNUT-Client_CommonLogger.vb: line number 91
   At WinNUT_Client.Pref_Gui.Btn_ViewLog_Click(Object sender, EventArgs e) position D:aWinNUT-ClientWinNUT-ClientWinNUT_V2WinNUT-ClientPref_Gui.vb: line number 341
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message&m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message&m)
   at System.Windows.Forms.Control.ControlNativeWindow.OnMessage(Message& m)
   at System.Windows.Forms.Control.ControlNativeWindow.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam,

https://github.com/nutdotnet/WinNUT-Client/pull/131/commits/da13d50a2cda2728e6a1e0cc008d4cba8697b6b0

# `System.OverflowException` and default values
Similar to the first report, [another OverflowException is reported](https://github.com/nutdotnet/WinNUT-Client/issues/129#issuecomment-1950971140) having to do with processing of UPS variables. It seems like this user's NUT server is reporting mostly out-of-range values for its variables.
> [6424, UPS_Device]: System.OverflowException thrown in mscorlib
Message: TimeSpan overflows because it lasts too long.
   at System.TimeSpan.Interval(Double value, Int32 scale)
   at System.TimeSpan.FromSeconds(Double value)
   At WinNUT_Client.WinNUT.Update_UPS_Data() position D:aWinNUT-ClientWinNUT-ClientWinNUT_V2WinNUT-ClientWinNUT.vb: line number 734
   At WinNUT_Client_Common.UPS_Device.Retrieve_UPS_Datas(Object sender, EventArgs e) location D:aWinNUT-ClientWinNUT-ClientWinNUT_V2WinNUT-Client_CommonUPS_Device.vb: line number 362
