### PR TITLE
Fixed the bug where the UPS using battery power was not displayed.

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -695,7 +695,7 @@ Public Class WinNUT
             UPS_InputV = .Input_Voltage
             UPS_OutputV = .Output_Voltage
             UPS_Load = .Load
-            UPS_Status = "OL"
+            UPS_Status = .UPS_Status
             UPS_OutPower = .Output_Power
 
             If .UPS_Status.HasFlag(UPS_States.OL) Then

--- a/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Common_Enums.vb
@@ -115,6 +115,7 @@ Public Enum UPS_States
     OVER = 1 << 10
     TRIM = 1 << 11
     BOOST = 1 << 12
+    ALARM = 1 << 13
 End Enum
 
 Public Enum PowerMethod


### PR DESCRIPTION
Add "ALARM" UPS States flag.The "ALARM" flag is still on my Huawei UPS200A device.
Fixed the bug where the UPS using battery power was not displayed.
![20240302131856](https://github.com/nutdotnet/WinNUT-Client/assets/19978097/b2f23463-f328-4081-9400-33fce1e588f4)
