### PR TITLE
Fix Application Settings not carrying over on upgrade/update

### DIFF
--- a/WinNUT_V2/.editorconfig
+++ b/WinNUT_V2/.editorconfig
@@ -6,7 +6,6 @@ root = true
 # All files
 [*]
 indent_style = space
-file_header_template = WinNUT-Client is a NUT windows client for monitoring your ups hooked up to your favorite linux server.\nCopyright (C) 2019-2021 Gawindx (Decaux Nicolas)\n\nThis program is free software: you can redistribute it and/or modify it under the terms of the\nGNU General Public License as published by the Free Software Foundation, either version 3 of the\nLicense, or any later version.\n\nThis program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without\neven the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU\nGeneral Public License for more details.\n\nYou should have received a copy of the GNU General Public License along with this program.\nIf not, see https://www.gnu.org/licenses/.\n
 # Code files
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
@@ -67,14 +66,16 @@ tab_width = 4
 end_of_line = crlf
 dotnet_style_allow_multiple_blank_lines_experimental = true:silent
 dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_code_quality_unused_parameters = all:suggestion
 ###############################
 # C# Coding Conventions       #
 ###############################
 [*.cs]
 # var preferences
-csharp_style_var_for_built_in_types = true:silent
-csharp_style_var_when_type_is_apparent = true:silent
-csharp_style_var_elsewhere = true:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:silent
 # Expression-bodied members
 csharp_style_expression_bodied_methods = false:silent
 csharp_style_expression_bodied_constructors = false:silent
@@ -149,6 +150,12 @@ csharp_style_prefer_readonly_struct_member = true:suggestion
 csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
 csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
 ###############################
 # VB Coding Conventions       #
 ###############################

--- a/WinNUT_V2/Setup/Setup.vdproj
+++ b/WinNUT_V2/Setup/Setup.vdproj
@@ -9379,7 +9379,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:AGauge, Version=2.1.8824.26289, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:AGauge, Version=2.1.8834.24289, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_7643B2E01E55816C8BA2265FF9E9B786"
@@ -11434,7 +11434,7 @@
             {
             "AssemblyRegister" = "3:1"
             "AssemblyIsInGAC" = "11:FALSE"
-            "AssemblyAsmDisplayName" = "8:WinNUT-Client_Common, Version=2.3.8824.26289, Culture=neutral, processorArchitecture=MSIL"
+            "AssemblyAsmDisplayName" = "8:WinNUT-Client_Common, Version=2.3.8834.24289, Culture=neutral, processorArchitecture=MSIL"
                 "ScatterAssemblies"
                 {
                     "_CB7240238DDFA669FCF3046E48D0A447"
@@ -12788,15 +12788,15 @@
         {
         "Name" = "8:Microsoft Visual Studio"
         "ProductName" = "8:WinNUT Client"
-        "ProductCode" = "8:{ED2181E2-D5FB-43AE-B50E-A0D019730CEB}"
-        "PackageCode" = "8:{5AAB5E2D-D11E-46D6-906F-F0F7385AFB42}"
+        "ProductCode" = "8:{AAAE0531-0B77-4CE7-A034-1583EA07BD87}"
+        "PackageCode" = "8:{8DFC349A-62F6-4FF2-BB1F-7C42432D8772}"
         "UpgradeCode" = "8:{7EA17151-76E7-4E29-8F6A-621C1B4144C2}"
         "AspNetVersion" = "8:2.0.50727.0"
         "RestartWWWService" = "11:FALSE"
         "RemovePreviousVersions" = "11:TRUE"
         "DetectNewerInstalledVersion" = "11:TRUE"
         "InstallAllUsers" = "11:FALSE"
-        "ProductVersion" = "8:2.3.8824"
+        "ProductVersion" = "8:2.3.8834"
         "Manufacturer" = "8:NUTDotNet"
         "ARPHELPTELEPHONE" = "8:"
         "ARPHELPLINK" = "8:https://github.com/nutdotnet/WinNUT-Client/issues"

--- a/WinNUT_V2/SharedAssemblyInfo.vb
+++ b/WinNUT_V2/SharedAssemblyInfo.vb
@@ -1,36 +1,10 @@
-﻿' WinNUT-Client is a NUT windows client for monitoring your ups hooked up to your favorite linux server.
-' Copyright (C) 2019-2021 Gawindx (Decaux Nicolas)
-'
-' This program is free software: you can redistribute it and/or modify it under the terms of the
-' GNU General Public License as published by the Free Software Foundation, either version 3 of the
-' License, or any later version.
-'
-' This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY
-
+﻿Imports System.Reflection
 Imports System.Resources
-Imports System.Reflection
-
-' Les informations générales relatives à un assembly dépendent de
-' l'ensemble d'attributs suivant. Changez les valeurs de ces attributs pour modifier les informations
-' associées à un assembly.
-
-' Vérifiez les valeurs des attributs de l'assembly
 
 <Assembly: AssemblyCompany("NUTDotNet")>
 <Assembly: AssemblyProduct("WinNUT Client")>
 <Assembly: AssemblyCopyright("NUTDotNet contributors © 2019-2024")>
 <Assembly: AssemblyTrademark("https://github.com/nutdotnet/WinNUT-Client")>
-
-' Les informations de version pour un assembly se composent des quatre valeurs suivantes :
-'
-'      Version principale
-'      Version secondaire
-'      Numéro de build
-'      Révision
-'
-' Vous pouvez spécifier toutes les valeurs ou indiquer les numéros de build et de révision par défaut
-' en utilisant '*', comme indiqué ci-dessous :
-' <Assembly: AssemblyVersion("1.0.*")>
 
 <Assembly: AssemblyVersion("2.3.*")>
 <Assembly: NeutralResourcesLanguage("en-US")>

--- a/WinNUT_V2/WinNUT-Client/App.config
+++ b/WinNUT_V2/WinNUT-Client/App.config
@@ -157,6 +157,9 @@
    <setting name="CAL_BattVMax" serializeAs="String">
     <value>18</value>
    </setting>
+   <setting name="IsFirstRun" serializeAs="String">
+    <value>True</value>
+   </setting>
   </WinNUT_Client.My.MySettings>
  </userSettings>
 </configuration>

--- a/WinNUT_V2/WinNUT-Client/ApplicationEvents.vb
+++ b/WinNUT_V2/WinNUT-Client/ApplicationEvents.vb
@@ -40,7 +40,24 @@ Namespace My
         Private Sub MyApplication_Startup(sender As Object, e As StartupEventArgs) Handles Me.Startup
             ' Uncomment below and comment out Handles line for _UnhandledException sub when debugging unhandled exceptions.
             ' AddHandler AppDomain.CurrentDomain.UnhandledException, AddressOf AppDomainUnhandledException
+
             Init_Globals()
+
+            ' If first run indicated by Settings, attempt upgrade in case older version is present.
+            ' Only necessary when deploying MSI. Remove once using pure ClickOnce.
+            If Settings.IsFirstRun Then
+                Try
+                    Settings.Upgrade()
+                    LogFile.LogTracing("Settings upgrade completed without exception.", LogLvl.LOG_NOTICE, Me)
+                Catch ex As ConfigurationErrorsException
+                    LogFile.LogTracing("Error encountered while trying to upgrade Settings:", LogLvl.LOG_ERROR, Me)
+                    LogFile.LogException(ex, Me)
+                End Try
+
+                Settings.IsFirstRun = False
+                Settings.Save()
+            End If
+
             LogFile.LogTracing("MyApplication_Startup complete.", LogLvl.LOG_DEBUG, Me)
         End Sub
 

--- a/WinNUT_V2/WinNUT-Client/My Project/AssemblyInfo.vb
+++ b/WinNUT_V2/WinNUT-Client/My Project/AssemblyInfo.vb
@@ -1,26 +1,7 @@
-﻿Imports System.Resources
-' WinNUT-Client is a NUT windows client for monitoring your ups hooked up to your favorite linux server.
-' Copyright (C) 2019-2021 Gawindx (Decaux Nicolas)
-'
-' This program is free software: you can redistribute it and/or modify it under the terms of the
-' GNU General Public License as published by the Free Software Foundation, either version 3 of the
-' License, or any later version.
-'
-' This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY
-
-Imports System.Reflection
+﻿Imports System.Reflection
 Imports System.Runtime.InteropServices
 
-' Les informations générales relatives à un assembly dépendent de
-' l'ensemble d'attributs suivant. Changez les valeurs de ces attributs pour modifier les informations
-' associées à un assembly.
-
-' Vérifiez les valeurs des attributs de l'assembly
-
 <Assembly: AssemblyTitle("WinNUT Client")>
-<Assembly: AssemblyDescription("")>
-
+<Assembly: AssemblyDescription("WinForms-based client for monitoring your Uninterruptible Power Supply (UPS) connected to a Network UPS Tools (NUT) server.")>
 <Assembly: ComVisible(False)>
-
-'Le GUID suivant est pour l'ID de la typelib si ce projet est exposé à COM
 <Assembly: Guid("00424259-e020-4e5c-a70a-5660aa21cb0b")>

--- a/WinNUT_V2/WinNUT-Client/My Project/Settings.Designer.vb
+++ b/WinNUT_V2/WinNUT-Client/My Project/Settings.Designer.vb
@@ -15,7 +15,7 @@ Option Explicit On
 Namespace My
     
     <Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
-     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0"),  _
+     Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0"),  _
      Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
     Partial Friend NotInheritable Class MySettings
         Inherits Global.System.Configuration.ApplicationSettingsBase
@@ -504,6 +504,18 @@ Namespace My
             End Get
             Set
                 Me("CAL_BattVMax") = value
+            End Set
+        End Property
+        
+        <Global.System.Configuration.UserScopedSettingAttribute(),  _
+         Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+         Global.System.Configuration.DefaultSettingValueAttribute("True")>  _
+        Public Property IsFirstRun() As Boolean
+            Get
+                Return CType(Me("IsFirstRun"),Boolean)
+            End Get
+            Set
+                Me("IsFirstRun") = value
             End Set
         End Property
     End Class

--- a/WinNUT_V2/WinNUT-Client/My Project/Settings.settings
+++ b/WinNUT_V2/WinNUT-Client/My Project/Settings.settings
@@ -116,5 +116,8 @@
     <Setting Name="CAL_BattVMax" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">18</Value>
     </Setting>
+    <Setting Name="IsFirstRun" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WinNUT_V2/WinNUT-Client/WinNUT-client.vbproj
+++ b/WinNUT_V2/WinNUT-Client/WinNUT-client.vbproj
@@ -112,6 +112,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
Closes #135 .

## Changes
- [x] Added new `IsFirstRun` User Setting (default True)
- [x] Insert block of code in the `ApplicationEvents` file that checks if this Setting is True, then attempts to call the Upgrade method.
- [x] Some small cleanup to the default header (removed) and cleaned up `AssemblyInfo` files.
- [x] Prepare new Pre Release