### PR TITLE
Fix  'Create LogFile'  option is on, but the option is not working when program is running.

### DIFF
--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
@@ -830,7 +830,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
 Please correct the error, or cancel the upgrade dialog to continue with the default settings.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</note>
         </trans-unit>
-        <trans-unit id="regedit_exe_14_100_0" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
+        <trans-unit id="regedit_exe_14_100_0" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="needs-review-translation">..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
@@ -1759,8 +1759,8 @@ Accepted value: Numeric value from 0 to 100.</source>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
           <source>Milliseconds between data updates from NUT server.
 Min: 100, Max: 60 000.</source>
-          <target state="needs-review-translation">UPS 資料更新頻率 (預設值 5 秒)。範圍：1-60 秒。</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Label3.ImeMode" translate="no" extype="System.Windows.Forms.ImeMode, System.Windows.Forms" xml:space="preserve">
           <source>NoControl</source>
@@ -2358,8 +2358,8 @@ Accepted value: Numeric value from 0 to 999.</source>
           <target state="translated">檢查應用程式更新。</target>
         </trans-unit>
         <trans-unit id="CB_Use_Logfile.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</source>
-          <target state="translated">建立日誌檔案 (WinNUT-client.log 檔案位於 WinNUT 的安裝目錄)。</target>
+          <source>Write logging events to a file.</source>
+          <target state="new">Write logging events to a file.</target>
         </trans-unit>
         <trans-unit id="Tb_OutV_Max.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>51, 20</source>
@@ -3667,74 +3667,73 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>WinNUT Client</source>
           <target state="final">WinNUT Client</target>
         </trans-unit>
-        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>133, 17</source>
           <target state="final">133, 17</target>
         </trans-unit>
-        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>364, 17</source>
           <target state="final">364, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>248, 17</source>
           <target state="final">248, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>58</source>
           <target state="final">58</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" xml:space="preserve" extype="System.Boolean, mscorlib">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>False</source>
           <target state="needs-review-translation">False</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>180, 22</source>
-          <target state="needs-review-translation">180, 22</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">180, 22</target>
         </trans-unit>
         <trans-unit id="ManageOldPrefsToolStripMenuItem.Text" translate="yes" xml:space="preserve">
           <source>Manage Old Prefs...</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
@@ -1237,8 +1237,8 @@
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
           <source>Milliseconds between data updates from NUT server.
 Min: 100, Max: 60 000.</source>
-          <target state="needs-review-translation">Zeit zwischen jeder Aktualisierung der USV-Daten (Standard = 5).Wertebereich: Numerischer Wert von 1 bis 60 Sekunden.</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.
@@ -1320,8 +1320,8 @@ Accepted value: Numeric value from 0 to 999.</source>
           <target state="translated">Detailstufe für die Logdatei</target>
         </trans-unit>
         <trans-unit id="CB_Use_Logfile.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</source>
-          <target state="translated">Eine Logdatei (Datei WinNUT-client.log im WinNUT-Installationsverzeichnis) erstellen.</target>
+          <source>Write logging events to a file.</source>
+          <target state="new">Write logging events to a file.</target>
         </trans-unit>
         <trans-unit id="CB_Start_W_Win.ToolTip" translate="yes" xml:space="preserve">
           <source>Starts WinNUT when Windows starts.</source>
@@ -1348,7 +1348,7 @@ Accepted value: Numeric value from 0 to 3600.</source>
           <source>Allow additional time during the shutdown procedure.
 Note: 
 This additional time could go beyond the UPS backup time - USE WITH CAUTION!!!</source>
-          <target state="translated">Zusätzliche Zeit zum Herunterfahrens erlauben. Hinweis: Diese zusätzliche Zeit kann über die Verfügbarkeit der USV hinausgehen - MIT VORSICHT VERWENDEN !!!</target>
+          <target state="translated">USV-Name</target>
         </trans-unit>
         <trans-unit id="Tb_Delay_Stop.ToolTip" translate="yes" xml:space="preserve">
           <source>Stop procedure delay if delayed.
@@ -1898,7 +1898,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
 Please correct the error, or cancel the upgrade dialog to continue with the default settings.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</note>
         </trans-unit>
-        <trans-unit id="regedit_exe_14_100_0" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
+        <trans-unit id="regedit_exe_14_100_0" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="needs-review-translation">..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
@@ -1936,7 +1936,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
     </header>
     <body>
       <group id="WINNUT-CLIENT/WINNUT.RESX" datatype="resx">
-        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>248, 17</source>
           <target state="final">248, 17</target>
         </trans-unit>
@@ -2044,12 +2044,11 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>704, 381</source>
           <target state="final">704, 381</target>
         </trans-unit>
-        <trans-unit id="$this.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="$this.Text" translate="no" xml:space="preserve">
           <source>WinNUT Client</source>
-          <target state="needs-review-translation">Windows NUT Client</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">WinNUT Client</target>
         </trans-unit>
-        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -2109,11 +2108,11 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>133, 17</source>
           <target state="final">133, 17</target>
         </trans-unit>
-        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>364, 17</source>
           <target state="final">364, 17</target>
         </trans-unit>
@@ -2489,7 +2488,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>None</source>
           <target state="final">None</target>
         </trans-unit>
-        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>58</source>
           <target state="final">58</target>
         </trans-unit>
@@ -3093,39 +3092,39 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>0, 24</source>
           <target state="final">0, 24</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -3149,7 +3148,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>6</source>
           <target state="final">6</target>
         </trans-unit>
-        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -3201,14 +3200,13 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>NoControl</source>
           <target state="final">NoControl</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" xml:space="preserve" extype="System.Boolean, mscorlib">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>False</source>
           <target state="needs-review-translation">False</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>180, 22</source>
-          <target state="needs-review-translation">180, 22</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">180, 22</target>
         </trans-unit>
         <trans-unit id="ManageOldPrefsToolStripMenuItem.Text" translate="yes" xml:space="preserve">
           <source>Manage Old Prefs...</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
@@ -1240,9 +1240,8 @@ inférieur à</target>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
           <source>Milliseconds between data updates from NUT server.
 Min: 100, Max: 60 000.</source>
-          <target state="needs-review-translation">Temps entre chaque mise à jour des données UPS (par défaut = 5).
-Valeur acceptée: valeur numérique de 1 à 60 secondes.</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.
@@ -1335,8 +1334,8 @@ Valeur acceptée: valeur numérique de 0 à 999.</target>
           <target state="final">Niveau de journalisation du fichier journal</target>
         </trans-unit>
         <trans-unit id="CB_Use_Logfile.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</source>
-          <target state="final">Créez un fichier journal (fichier "WinNUT-client.log" dans le répertoire d'installation de WinNUT).</target>
+          <source>Write logging events to a file.</source>
+          <target state="new">Write logging events to a file.</target>
         </trans-unit>
         <trans-unit id="CB_Start_W_Win.ToolTip" translate="yes" xml:space="preserve">
           <source>Starts WinNUT when Windows starts.</source>
@@ -1923,7 +1922,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
 Please correct the error, or cancel the upgrade dialog to continue with the default settings.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</note>
         </trans-unit>
-        <trans-unit id="regedit_exe_14_100_0" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
+        <trans-unit id="regedit_exe_14_100_0" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="needs-review-translation">..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
@@ -1961,7 +1960,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
     </header>
     <body>
       <group id="WINNUT-CLIENT/WINNUT.RESX" datatype="resx">
-        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>248, 17</source>
           <target state="final">248, 17</target>
         </trans-unit>
@@ -2069,12 +2068,11 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>704, 381</source>
           <target state="final">704, 381</target>
         </trans-unit>
-        <trans-unit id="$this.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="$this.Text" translate="no" xml:space="preserve">
           <source>WinNUT Client</source>
-          <target state="needs-review-translation">Windows NUT Client</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">WinNUT Client</target>
         </trans-unit>
-        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -2134,11 +2132,11 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>133, 17</source>
           <target state="final">133, 17</target>
         </trans-unit>
-        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>364, 17</source>
           <target state="final">364, 17</target>
         </trans-unit>
@@ -2514,7 +2512,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>None</source>
           <target state="final">None</target>
         </trans-unit>
-        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>58</source>
           <target state="final">58</target>
         </trans-unit>
@@ -3118,39 +3116,39 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>0, 24</source>
           <target state="final">0, 24</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -3174,7 +3172,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>6</source>
           <target state="final">6</target>
         </trans-unit>
-        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
@@ -3226,14 +3224,13 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
           <source>NoControl</source>
           <target state="final">NoControl</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" xml:space="preserve" extype="System.Boolean, mscorlib">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>False</source>
           <target state="needs-review-translation">False</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>180, 22</source>
-          <target state="needs-review-translation">180, 22</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">180, 22</target>
         </trans-unit>
         <trans-unit id="ManageOldPrefsToolStripMenuItem.Text" translate="yes" xml:space="preserve">
           <source>Manage Old Prefs...</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
@@ -835,7 +835,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
 Please correct the error, or cancel the upgrade dialog to continue with the default settings.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</note>
         </trans-unit>
-        <trans-unit id="regedit_exe_14_100_0" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
+        <trans-unit id="regedit_exe_14_100_0" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="needs-review-translation">..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
@@ -1291,9 +1291,8 @@ along with this program. If not, see https://www.gnu.org/licenses/.</target>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
           <source>Milliseconds between data updates from NUT server.
 Min: 100, Max: 60 000.</source>
-          <target state="needs-review-translation">Время между обновлениями данных ИБП (по умолчанию = 5).
-Число от 1 до 60 секунд.</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
@@ -1918,8 +1917,8 @@ Accepted value: Numeric value from 0 to 999.</source>
           <target state="final">Создать файл лога</target>
         </trans-unit>
         <trans-unit id="CB_Use_Logfile.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</source>
-          <target state="final">Создать файл лога (файл WinNUT-client.log в папке установки WinNUT).</target>
+          <source>Write logging events to a file.</source>
+          <target state="new">Write logging events to a file.</target>
         </trans-unit>
         <trans-unit id="CB_Start_W_Win.AutoSize" translate="no" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>True</source>
@@ -3682,68 +3681,67 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>720, 420</source>
           <target state="final">720, 420</target>
         </trans-unit>
-        <trans-unit id="$this.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="$this.Text" translate="no" xml:space="preserve">
           <source>WinNUT Client</source>
-          <target state="needs-review-translation">Windows NUT CLient</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">WinNUT Client</target>
         </trans-unit>
-        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>133, 17</source>
           <target state="final">133, 17</target>
         </trans-unit>
-        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>364, 17</source>
           <target state="final">364, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>248, 17</source>
           <target state="final">248, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>58</source>
           <target state="final">58</target>
         </trans-unit>
@@ -3751,14 +3749,13 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>NoControl</source>
           <target state="final">NoControl</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" xml:space="preserve" extype="System.Boolean, mscorlib">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>False</source>
           <target state="needs-review-translation">False</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>180, 22</source>
-          <target state="needs-review-translation">180, 22</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">180, 22</target>
         </trans-unit>
         <trans-unit id="ManageOldPrefsToolStripMenuItem.Text" translate="yes" xml:space="preserve">
           <source>Manage Old Prefs...</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
@@ -835,7 +835,7 @@ Please correct the error, or cancel the upgrade dialog to continue with the defa
 Please correct the error, or cancel the upgrade dialog to continue with the default settings.</target>
           <note from="MultilingualBuild" annotates="source" priority="2">Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</note>
         </trans-unit>
-        <trans-unit id="regedit_exe_14_100_0" translate="yes" xml:space="preserve" extype="System.Resources.ResXFileRef, System.Windows.Forms">
+        <trans-unit id="regedit_exe_14_100_0" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="needs-review-translation">..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
@@ -1455,9 +1455,8 @@ Accepted value: Numeric value from 0 to 999.</source>
         <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
           <source>Milliseconds between data updates from NUT server.
 Min: 100, Max: 60 000.</source>
-          <target state="needs-review-translation">每次更新UPS数据之间的时间（默认= 5）。
-接受值：1到60秒之间的数值。</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">Milliseconds between data updates from NUT server.
+Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
@@ -1754,8 +1753,8 @@ Accepted value: IPV4 / IPV6 / FQDN address.</source>
           <target state="final">创建日志文件</target>
         </trans-unit>
         <trans-unit id="CB_Use_Logfile.ToolTip" translate="yes" xml:space="preserve">
-          <source>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</source>
-          <target state="final">创建日志文件（""WinNUT-client.log"" 文件位于 WinNUT 的安装目录）。</target>
+          <source>Write logging events to a file.</source>
+          <target state="new">Write logging events to a file.</target>
         </trans-unit>
         <trans-unit id="CB_Start_W_Win.AutoSize" translate="no" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>True</source>
@@ -3669,68 +3668,67 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>720, 420</source>
           <target state="final">720, 420</target>
         </trans-unit>
-        <trans-unit id="$this.Text" translate="yes" xml:space="preserve">
+        <trans-unit id="$this.Text" translate="no" xml:space="preserve">
           <source>WinNUT Client</source>
-          <target state="needs-review-translation">Windows NUT Client</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="final">WinNUT Client</target>
         </trans-unit>
-        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="NotifyIcon.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>133, 17</source>
           <target state="final">133, 17</target>
         </trans-unit>
-        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="ContextMenu_Systray.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>364, 17</source>
           <target state="final">364, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.TrayLocation" translate="no" extype="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" extradata="metadata" xml:space="preserve">
           <source>248, 17</source>
           <target state="final">248, 17</target>
         </trans-unit>
-        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="Main_Menu.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Status.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_OutV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattCh_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_Load_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_BattV_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="GB_InF_Dial.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="CB_CurrentLog.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Localizable" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.Locked" translate="no" extype="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>True</source>
           <target state="final">True</target>
         </trans-unit>
-        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" xml:space="preserve" extradata="metadata">
+        <trans-unit id="$this.TrayHeight" translate="no" extype="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" extradata="metadata" xml:space="preserve">
           <source>58</source>
           <target state="final">58</target>
         </trans-unit>
@@ -3750,14 +3748,13 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>NoControl</source>
           <target state="final">NoControl</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" xml:space="preserve" extype="System.Boolean, mscorlib">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
           <source>False</source>
           <target state="needs-review-translation">False</target>
         </trans-unit>
-        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" xml:space="preserve" extype="System.Drawing.Size, System.Drawing">
+        <trans-unit id="ManageOldPrefsToolStripMenuItem.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>180, 22</source>
-          <target state="needs-review-translation">180, 22</target>
-          <note from="MultilingualUpdate" annotates="source" priority="2">Please verify the translation’s accuracy as the source string was updated after it was translated.</note>
+          <target state="new">180, 22</target>
         </trans-unit>
         <trans-unit id="ManageOldPrefsToolStripMenuItem.Text" translate="yes" xml:space="preserve">
           <source>Manage Old Prefs...</source>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.de-DE.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.de-DE.resx
@@ -165,9 +165,6 @@
   <data name="$this.Text" xml:space="preserve">
     <value>Optionen</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>Zeit zwischen jeder Aktualisierung der USV-Daten (Standard = 5).Wertebereich: Numerischer Wert von 1 bis 60 Sekunden.</value>
-  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>Name der zu überwachenden USV. Wertebereich: Name der auf dem NUT-Server konfigurierten USV.</value>
   </data>
@@ -219,9 +216,6 @@
   <data name="Lbl_LevelLog.ToolTip" xml:space="preserve">
     <value>Detailstufe für die Logdatei</value>
   </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>Eine Logdatei (Datei WinNUT-client.log im WinNUT-Installationsverzeichnis) erstellen.</value>
-  </data>
   <data name="CB_Start_W_Win.ToolTip" xml:space="preserve">
     <value>Startet WinNUT beim Start von Windows.</value>
   </data>
@@ -238,7 +232,7 @@
     <value>Limit für zusätzliche Verzögerung. Wertebereich: Numerischer Wert von 0 bis 3600.</value>
   </data>
   <data name="Cb_ExtendTime.ToolTip" xml:space="preserve">
-    <value>Zusätzliche Zeit zum Herunterfahrens erlauben. Hinweis: Diese zusätzliche Zeit kann über die Verfügbarkeit der USV hinausgehen - MIT VORSICHT VERWENDEN !!!</value>
+    <value>USV-Name</value>
   </data>
   <data name="Tb_Delay_Stop.ToolTip" xml:space="preserve">
     <value>Prozedurverzögerung bei Verzögerung stoppen. Wertebereich: Numerischer Wert von 0 bis 3600.</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.fr-FR.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.fr-FR.resx
@@ -168,10 +168,6 @@ inférieur à</value>
   <data name="$this.Text" xml:space="preserve">
     <value>Préférences</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>Temps entre chaque mise à jour des données UPS (par défaut = 5).
-Valeur acceptée: valeur numérique de 1 à 60 secondes.</value>
-  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>Nom de l'onduleur à surveiller.
 Valeur acceptée: nom de l'onduleur configuré dans le serveur Nut.</value>
@@ -233,9 +229,6 @@ Valeur acceptée: valeur numérique de 0 à 999.</value>
   </data>
   <data name="Lbl_LevelLog.ToolTip" xml:space="preserve">
     <value>Niveau de journalisation du fichier journal</value>
-  </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>Créez un fichier journal (fichier "WinNUT-client.log" dans le répertoire d'installation de WinNUT).</value>
   </data>
   <data name="CB_Start_W_Win.ToolTip" xml:space="preserve">
     <value>Démarre WinNUT au démarrage de Windows.</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
@@ -1168,7 +1168,7 @@ Accepted value: Numeric value from 0 to 999.</value>
     <value>Create LogFile</value>
   </data>
   <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>Create a log file ("WinNUT-client.log" file in the WinNUT installation directory).</value>
+    <value>Write logging events to a file.</value>
   </data>
   <data name="&gt;&gt;CB_Use_Logfile.Name" xml:space="preserve">
     <value>CB_Use_Logfile</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.ru-RU.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.ru-RU.resx
@@ -81,10 +81,6 @@
   <data name="Lbl_Login_Nut.Text" xml:space="preserve">
     <value>Логин</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>Время между обновлениями данных ИБП (по умолчанию = 5).
-Число от 1 до 60 секунд.</value>
-  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>Имя ИБП для мониторинга.
 Допустимые значения: Имя ИБП из конфиграции сервера NUT</value>
@@ -203,9 +199,6 @@ IPV4 / IPV6 / доменное имя.</value>
   </data>
   <data name="CB_Use_Logfile.Text" xml:space="preserve">
     <value>Создать файл лога</value>
-  </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>Создать файл лога (файл WinNUT-client.log в папке установки WinNUT).</value>
   </data>
   <data name="CB_Start_W_Win.Text" xml:space="preserve">
     <value>Запускать с Windows</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.vb
@@ -183,6 +183,7 @@ Public Class Pref_Gui
                 Next
             Next
             Btn_Apply.Enabled = False
+            SetLogControlsStatus()
             IsShowed = True
             LogFile.LogTracing("Pref Gui Opened.", LogLvl.LOG_DEBUG, Me)
         Catch Except As Exception

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
@@ -101,10 +101,6 @@
   <data name="Lbl_Login_Nut.Text" xml:space="preserve">
     <value>登录</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>每次更新UPS数据之间的时间（默认= 5）。
-接受值：1到60秒之间的数值。</value>
-  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>监控的 UPS 名称。
 允许值：在 UPS 的 Nut 服务端所配置的名称。</value>
@@ -164,9 +160,6 @@
   </data>
   <data name="CB_Use_Logfile.Text" xml:space="preserve">
     <value>创建日志文件</value>
-  </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>创建日志文件（""WinNUT-client.log"" 文件位于 WinNUT 的安装目录）。</value>
   </data>
   <data name="CB_Start_W_Win.Text" xml:space="preserve">
     <value>随 Windows 启动当前应用</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-TW.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-TW.resx
@@ -174,9 +174,6 @@
   <data name="Cbx_LogLevel.Items3" xml:space="preserve">
     <value>除錯</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>UPS 資料更新頻率 (預設值 5 秒)。範圍：1-60 秒。</value>
-  </data>
   <data name="CB_Systray.Text" xml:space="preserve">
     <value>最小化至系統匣</value>
   </data>
@@ -260,9 +257,6 @@
   </data>
   <data name="Cb_Verify_Update.ToolTip" xml:space="preserve">
     <value>檢查應用程式更新。</value>
-  </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>建立日誌檔案 (WinNUT-client.log 檔案位於 WinNUT 的安裝目錄)。</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
     <value>選項</value>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.de-DE.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.de-DE.resx
@@ -42,9 +42,6 @@
   <data name="Menu_Help.Text" xml:space="preserve">
     <value>Hilfe</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Windows NUT Client</value>
-  </data>
   <data name="Menu_Sys_Settings.Text" xml:space="preserve">
     <value>Einstellungen</value>
   </data>
@@ -104,8 +101,5 @@
   </data>
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.fr-FR.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.fr-FR.resx
@@ -42,9 +42,6 @@
   <data name="Menu_Help.Text" xml:space="preserve">
     <value>Aide</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Windows NUT Client</value>
-  </data>
   <data name="Menu_Sys_Settings.Text" xml:space="preserve">
     <value>Réglages</value>
   </data>
@@ -104,8 +101,5 @@
   </data>
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.ru-RU.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.ru-RU.resx
@@ -99,13 +99,7 @@
   <data name="Lbl_InF_Dial.Text" xml:space="preserve">
     <value>Частота</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Windows NUT CLient</value>
-  </data>
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -138,6 +138,14 @@ Public Class WinNUT
         StrLog.Insert(AppResxStr.STR_LOG_UPDATE, My.Resources.Log_Str_11)
         StrLog.Insert(AppResxStr.STR_LOG_NUT_FSD, My.Resources.Log_Str_12)
 
+        'Init Logger
+        If My.Settings.LG_LogToFile Then
+            LogFile.LogLevelValue = My.Settings.LG_LogLevel
+            LogFile.InitializeLogFile()
+        ElseIf LogFile.IsWritingToFile Then
+            LogFile.DeleteLogFile()
+        End If
+
         'Init Systray
         NotifyIcon.Text = ProgramName & " - " & ShortProgramVersion
         NotifyIcon.Visible = False

--- a/WinNUT_V2/WinNUT-Client/WinNUT.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.zh-CN.resx
@@ -99,13 +99,7 @@
   <data name="Lbl_InF_Dial.Text" xml:space="preserve">
     <value>频率</value>
   </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Windows NUT Client</value>
-  </data>
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
-  </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.zh-TW.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.zh-TW.resx
@@ -102,7 +102,4 @@
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="ManageOldPrefsToolStripMenuItem.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
-    <value>180, 22</value>
-  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client_Common/WinNUT-Client_Common.vbproj
+++ b/WinNUT_V2/WinNUT-Client_Common/WinNUT-Client_Common.vbproj
@@ -23,7 +23,8 @@
     <DocumentationFile>
     </DocumentationFile>
     <NoWarn>42016,41999,42017,42018,42019,42032,42036,42020,42021,42022</NoWarn>
-    <DefineConstants>TEST_RELEASE_DIRS</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
1.Fix LogFile controls are disabled when the Create LogFile option is on.
![20240420234658](https://github.com/nutdotnet/WinNUT-Client/assets/19978097/38865229-e7ae-4e91-8023-d4ebb0ccb951)

#142 

2.Fix  'Create LogFile'  option is on, but the option is not working when program is running.

