### PR TITLE
Resuming from Sleep and other connection fixes

### DIFF
--- a/WinNUT_V2/WinNUT-Client/About_Gui.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/About_Gui.zh-CN.resx
@@ -12,18 +12,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Label_License.Text" xml:space="preserve">
-    <value>This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published 
-by the Free Software Foundation, either version 3 of the License, or
-any later version.
-
-This program is distributed in the hope that it will be useful, but
-WITHOUT ANY WARRANTY; without even the implied warranty
-of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-See the GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program. If not, see https://www.gnu.org/licenses/.</value>
-  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/My Project/Resources.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/My Project/Resources.zh-CN.resx
@@ -121,32 +121,33 @@ Ini 文件重命名为 {0}.old</value>
   <data name="XP_Information" xml:space="preserve" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="regedit_exe_14_100_0" xml:space="preserve" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
-  </data>
-  <data name="GitHub_URL" xml:space="preserve">
-    <value>https://github.com/nutdotnet/WinNUT-Client</value>
-  </data>
   <data name="DetectedPreviousPrefsData" xml:space="preserve">
     <value>在注册表中检测到以前的设置数据。</value>
+    <comment>Notify the user that preferences data from the old system was detected in the Registry hive.</comment>
   </data>
   <data name="UpgradePrefsDialog_ImportProcedureCompleted" xml:space="preserve">
     <value>旧设置已经被导入。</value>
+    <comment>Notify the user that the import procedure has completed.</comment>
   </data>
   <data name="UpgradePrefsDialog_UnmatchedPairs" xml:space="preserve">
     <value>有 {0} 个未知的设置。请查看日志获取更多详细信息。</value>
+    <comment>Alert the user to how many unmatched preferences there were {0}.</comment>
   </data>
   <data name="UpgradePrefsDialog_DeleteProcedureComplete" xml:space="preserve">
     <value>旧设置已经从您的注册表中删除。</value>
+    <comment>Notify the user that the old preferences have been removed from their Registry.</comment>
   </data>
   <data name="UpgradePrefsDialog_Cancelled" xml:space="preserve">
     <value>升级过程已取消：使用默认设置。</value>
+    <comment>Notify the user that the upgrade dialog was cancelled, and that default settings will be used instead.</comment>
   </data>
   <data name="UpgradePrefsDialog_BackupLocationTitle" xml:space="preserve">
     <value>保存 WinNUT 注册表</value>
+    <comment>Title of the SaveFileDialog that prompts the user to select the file and location they would like to save their WinNUT Registry preferences to.</comment>
   </data>
   <data name="UpgradePrefsDialog_BackupProcedureCompleted" xml:space="preserve">
     <value>旧设置已备份到 {0}</value>
+    <comment>Notify the user that the old preferences have been exported to a file, and give the full path with {0}.</comment>
   </data>
   <data name="UpgradePrefsDialog_ErrorEncountered" xml:space="preserve">
     <value>升级过程中发生错误：
@@ -154,20 +155,29 @@ Ini 文件重命名为 {0}.old</value>
 {0}
 
 请修复错误，或取消升级对话框以继续使用默认设置。</value>
+    <comment>Alert the user that an error occurred during the upgrade procedure, attempt to give a brief summary of the error, and prompt them to take the next step.</comment>
+  </data>
+  <data name="regedit_exe_14_100_0" xml:space="preserve" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\regedit.exe_14_100-0.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
   <data name="UpgradePrefsDialog_NoPrefsExistCaption" xml:space="preserve">
     <value>没有检测到设置</value>
+    <comment>A brief caption for the error message.</comment>
   </data>
   <data name="UpgradePrefsDialog_NoPrefsExistError" xml:space="preserve">
     <value>您的系统中未检测到设置。无法继续操作。</value>
+    <comment>Alert the user that the dialog is unable to continue, since no preferences are detected in the Registry.</comment>
   </data>
   <data name="ManageOldPrefsToolstripMenuItem_Disabled_TooltipText" xml:space="preserve">
     <value>您的系统中未检测到旧设置。</value>
+    <comment>Similar to _Enabled tooltip, except that the preferences were not detected.</comment>
   </data>
   <data name="ManageOldPrefsToolstripMenuItem_Enabled_TooltipText" xml:space="preserve">
     <value>检测到旧设置。点击运行导入向导。</value>
+    <comment>Tooltip of the "manage old prefs" menu item, explaining that the old preferences were detected and that clicking will open the wizard dialog.</comment>
   </data>
   <data name="VariableUnavailable" xml:space="preserve">
     <value>参数无效</value>
+    <comment>Indicate that a variable is unavailable</comment>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
@@ -101,6 +101,10 @@
   <data name="Lbl_Login_Nut.Text" xml:space="preserve">
     <value>登录</value>
   </data>
+  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
+    <value>从NUT服务器更新数据时间间隔（单位：毫秒）。
+最小值: 100, 最大值: 60 000。</value>
+  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>监控的 UPS 名称。
 允许值：在 UPS 的 Nut 服务端所配置的名称。</value>
@@ -160,6 +164,9 @@
   </data>
   <data name="CB_Use_Logfile.Text" xml:space="preserve">
     <value>创建日志文件</value>
+  </data>
+  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
+    <value>将日志事件写入文件。</value>
   </data>
   <data name="CB_Start_W_Win.Text" xml:space="preserve">
     <value>随 Windows 启动当前应用</value>
@@ -315,18 +322,5 @@
   </data>
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
-  </data>
-  <data name="Cbx_Freq_Input.Items" xml:space="preserve">
-    <value>50</value>
-  </data>
-  <data name="Cbx_Freq_Input.Items1" xml:space="preserve">
-    <value>60</value>
-  </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>从NUT服务器更新数据时间间隔（单位：毫秒）。
-最小值: 100, 最大值: 60 000。</value>
-  </data>
-  <data name="CB_Use_Logfile.ToolTip" xml:space="preserve">
-    <value>将日志事件写入文件。</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/UpgradePrefsDialog.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/UpgradePrefsDialog.zh-CN.resx
@@ -42,6 +42,9 @@
   <data name="IntroMessage.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
+  <data name="IntroMessage.Text" xml:space="preserve">
+    <value>WinNUT已经升级到一个新的设置和设置系统，并且必须继续使用它。在注册表中检测到了一些旧程序的设置。请从下面选择您希望对旧设置进行的操作。如果您不希望采取任何操作，请选择取消，将使用默认设置。只要新的程序数据保持完整，将不会再显示此消息。</value>
+  </data>
   <data name="OK_Button.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
   </data>
@@ -56,6 +59,9 @@
   </data>
   <data name="OK_Button.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>0</value>
+  </data>
+  <data name="OK_Button.Text" xml:space="preserve">
+    <value>确认</value>
   </data>
   <data name="Cancel_Button.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Right</value>
@@ -72,6 +78,9 @@
   <data name="Cancel_Button.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
+  <data name="Cancel_Button.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
   <data name="ImportSettingsCheckBox.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -87,6 +96,12 @@
   <data name="ImportSettingsCheckBox.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>5</value>
   </data>
+  <data name="ImportSettingsCheckBox.Text" xml:space="preserve">
+    <value>导入</value>
+  </data>
+  <data name="ImportSettingsCheckBox.ToolTip" xml:space="preserve">
+    <value>旧设置将从注册表导入到新的设置系统中。</value>
+  </data>
   <data name="DeleteSettingsCheckBox.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -101,6 +116,12 @@
   </data>
   <data name="DeleteSettingsCheckBox.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>6</value>
+  </data>
+  <data name="DeleteSettingsCheckBox.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="DeleteSettingsCheckBox.ToolTip" xml:space="preserve">
+    <value>在注册表中检测到旧设置数据。</value>
   </data>
   <data name="PrevSettngsGroupBox.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left, Right</value>
@@ -120,6 +141,12 @@
   <data name="BackupSettingsCheckbox.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>7</value>
   </data>
+  <data name="BackupSettingsCheckbox.Text" xml:space="preserve">
+    <value>备份</value>
+  </data>
+  <data name="BackupSettingsCheckbox.ToolTip" xml:space="preserve">
+    <value>旧设置将被导出到文件中。</value>
+  </data>
   <data name="PrevSettngsGroupBox.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
     <value>6, 122</value>
   </data>
@@ -131,6 +158,9 @@
   </data>
   <data name="PrevSettngsGroupBox.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
     <value>7</value>
+  </data>
+  <data name="PrevSettngsGroupBox.Text" xml:space="preserve">
+    <value>以前的设置</value>
   </data>
   <data name="buttonPanel.Dock" xml:space="preserve" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Bottom</value>
@@ -180,6 +210,9 @@
   <data name="$this.StartPosition" xml:space="preserve" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>
   </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>迁移到新设置格式</value>
+  </data>
   <metadata name="UpgradePrefsDialogModelBindingSource.TrayLocation" xml:space="preserve" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>488, 17</value>
   </metadata>
@@ -195,39 +228,4 @@
   <metadata name="$this.TrayHeight" xml:space="preserve" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>44</value>
   </metadata>
-  <data name="IntroMessage.Text" xml:space="preserve">
-    <value>WinNUT已经升级到一个新的设置和设置系统，并且必须继续使用它。在注册表中检测到了一些旧程序的设置。请从下面选择您希望对旧设置进行的操作。如果您不希望采取任何操作，请选择取消，将使用默认设置。只要新的程序数据保持完整，将不会再显示此消息。
-
-</value>
-  </data>
-  <data name="OK_Button.Text" xml:space="preserve">
-    <value>确认</value>
-  </data>
-  <data name="Cancel_Button.Text" xml:space="preserve">
-    <value>取消</value>
-  </data>
-  <data name="ImportSettingsCheckBox.Text" xml:space="preserve">
-    <value>导入</value>
-  </data>
-  <data name="ImportSettingsCheckBox.ToolTip" xml:space="preserve">
-    <value>旧设置将从注册表导入到新的设置系统中。</value>
-  </data>
-  <data name="DeleteSettingsCheckBox.Text" xml:space="preserve">
-    <value>删除</value>
-  </data>
-  <data name="DeleteSettingsCheckBox.ToolTip" xml:space="preserve">
-    <value>在注册表中检测到旧设置数据。</value>
-  </data>
-  <data name="BackupSettingsCheckbox.Text" xml:space="preserve">
-    <value>备份</value>
-  </data>
-  <data name="BackupSettingsCheckbox.ToolTip" xml:space="preserve">
-    <value>旧设置将被导出到文件中。</value>
-  </data>
-  <data name="PrevSettngsGroupBox.Text" xml:space="preserve">
-    <value>以前的设置</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>迁移到新设置格式</value>
-  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -383,6 +383,10 @@ Public Class WinNUT
         UPS_Device = New UPS_Device(Nut_Config, LogFile, My.Settings.NUT_PollIntervalMsec, My.Settings.CAL_FreqInNom)
         AddHandler UPS_Device.EncounteredNUTException, AddressOf HandleNUTException
         UPS_Device.Connect_UPS(retryOnConnFailure)
+
+        If Not String.IsNullOrEmpty(Nut_Config.Login) Then
+            UPS_Device.Login()
+        End If
     End Sub
 
     ''' <summary>
@@ -409,8 +413,8 @@ Public Class WinNUT
     End Sub
 
     Private Sub ConnectionError(sender As UPS_Device, ex As Exception) Handles UPS_Device.ConnectionError
-        LogFile.LogTracing(String.Format("Something went wrong connecting to UPS {0}. IsConnected: {1}, IsAuthenticated: {2}",
-                               sender.Name, sender.IsConnected, sender.IsAuthenticated), LogLvl.LOG_ERROR, Me,
+        LogFile.LogTracing(String.Format("Something went wrong connecting to UPS {0}. IsConnected: {1}, IsLoggedIn: {2}",
+                               sender.Name, sender.IsConnected, sender.IsLoggedIn), LogLvl.LOG_ERROR, Me,
                                String.Format(StrLog.Item(AppResxStr.STR_LOG_CON_FAILED), sender.Nut_Config.Host, sender.Nut_Config.Port,
                                              ex.Message))
     End Sub

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -345,6 +345,9 @@ Public Class WinNUT
     Private Sub SystemEvents_PowerModeChanged(sender As Object, e As Microsoft.Win32.PowerModeChangedEventArgs)
         LogFile.LogTracing("PowerModeChangedEvent: " & [Enum].GetName(GetType(Microsoft.Win32.PowerModes), e.Mode), LogLvl.LOG_NOTICE, Me)
         Select Case e.Mode
+            Case Microsoft.Win32.PowerModes.Suspend
+                LogFile.LogTracing("Suspending WinNUT operations...", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
+                UPSDisconnect()
             Case Microsoft.Win32.PowerModes.Resume
                 LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
                 If My.Settings.NUT_AutoReconnect Then

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -383,16 +383,12 @@ Public Class WinNUT
         UPS_Device = New UPS_Device(Nut_Config, LogFile, My.Settings.NUT_PollIntervalMsec, My.Settings.CAL_FreqInNom)
         AddHandler UPS_Device.EncounteredNUTException, AddressOf HandleNUTException
         UPS_Device.Connect_UPS(retryOnConnFailure)
-
-        If Not String.IsNullOrEmpty(Nut_Config.Login) Then
-            UPS_Device.Login()
-        End If
     End Sub
 
     ''' <summary>
     ''' Prepare the form to begin receiving data from a connected UPS.
     ''' </summary>
-    Private Sub UPSReady(nutUps As UPS_Device) Handles UPS_Device.Connected, UPS_Device.ReConnected
+    Private Sub UPSReady(nutUps As UPS_Device) Handles UPS_Device.Connected
         Dim upsConf = nutUps.Nut_Config
         LogFile.LogTracing(upsConf.UPSName & " has indicated it's ready to start sending data.", LogLvl.LOG_DEBUG, Me)
 
@@ -410,6 +406,10 @@ Public Class WinNUT
         LogFile.LogTracing("Connection to Nut Host Established", LogLvl.LOG_NOTICE, Me,
                            String.Format(StrLog.Item(AppResxStr.STR_LOG_CONNECTED),
                                          upsConf.Host, upsConf.Port))
+
+        If Not String.IsNullOrEmpty(upsConf.Login) Then
+            UPS_Device.Login()
+        End If
     End Sub
 
     Private Sub ConnectionError(sender As UPS_Device, ex As Exception) Handles UPS_Device.ConnectionError
@@ -596,7 +596,8 @@ Public Class WinNUT
             Event_Unknown_UPS()
         End If
 
-        LogFile.LogTracing("NUT protocol error encoutnered:" + vbNewLine + ex.ToString(), LogLvl.LOG_NOTICE, sender)
+        LogFile.LogTracing("NUT protocol error encoutnered:", LogLvl.LOG_NOTICE, sender)
+        LogFile.LogException(ex, Me)
     End Sub
 
     Public Sub Event_Unknown_UPS() ' Handles UPS_Device.Unknown_UPS
@@ -623,7 +624,7 @@ Public Class WinNUT
     End Sub
 
     Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,
-        UPS_Device.Lost_Connect, UPS_Device.Connected, UPS_Device.Disconnected, UPS_Device.New_Retry, UPS_Device.ReConnected
+        UPS_Device.Lost_Connect, UPS_Device.Connected, UPS_Device.Disconnected, UPS_Device.New_Retry
         ', UPS_Device.Unknown_UPS
         ', UPS_Device.InvalidLogin
 

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -12,20 +12,6 @@ Imports WinNUT_Client_Common
 Public Class WinNUT
 #Region "Properties"
 
-    Public Property UpdateMethod() As String
-        Get
-            If mUpdate Then
-                mUpdate = False
-                Return True
-            Else
-                Return False
-            End If
-        End Get
-        Set(Value As String)
-            mUpdate = Value
-        End Set
-    End Property
-
     Public WriteOnly Property HasCrashed() As Boolean
         Set(Value As Boolean)
             WinNUT_Crashed = Value
@@ -78,7 +64,6 @@ Public Class WinNUT
     Public UPS_InputA As Double
 
     Private HasFocus As Boolean = True
-    Private mUpdate As Boolean = False
     Private FormText As String
     Private WinNUT_Crashed As Boolean = False
 
@@ -349,10 +334,10 @@ Public Class WinNUT
                 LogFile.LogTracing("Suspending WinNUT operations...", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
                 UPSDisconnect()
             Case Microsoft.Win32.PowerModes.Resume
-                LogFile.LogTracing("Restarting WinNUT after waking up from Windows", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
                 If My.Settings.NUT_AutoReconnect Then
-                    UPS_Connect(True)
-                End If
+                        LogFile.LogTracing("Reconnecting after system resume.", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
+                        UPS_Connect(True)
+                    End If
         End Select
     End Sub
 
@@ -1048,12 +1033,11 @@ Public Class WinNUT
     End Sub
 
     Private Sub Menu_Update_Click(sender As Object, e As EventArgs) Handles Menu_Update.Click
-        mUpdate = True
         'Dim th As System.Threading.Thread = New Threading.Thread(New System.Threading.ParameterizedThreadStart(AddressOf Run_Update))
         'th.SetApartmentState(System.Threading.ApartmentState.STA)
         'th.Start(Me.UpdateMethod)
         LogFile.LogTracing("Open About Gui From Menu", LogLvl.LOG_DEBUG, Me)
-        Dim Update_Frm = New Update_Gui(mUpdate)
+        Dim Update_Frm = New Update_Gui(True)
         Update_Frm.Activate()
         Update_Frm.Visible = True
         HasFocus = False

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -330,14 +330,19 @@ Public Class WinNUT
     Private Sub SystemEvents_PowerModeChanged(sender As Object, e As Microsoft.Win32.PowerModeChangedEventArgs)
         LogFile.LogTracing("PowerModeChangedEvent: " & [Enum].GetName(GetType(Microsoft.Win32.PowerModes), e.Mode), LogLvl.LOG_NOTICE, Me)
         Select Case e.Mode
+            ' Note: Windows does not wait for applications to handle a Suspend event.
             Case Microsoft.Win32.PowerModes.Suspend
                 LogFile.LogTracing("Suspending WinNUT operations...", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_GOTOSLEEP))
                 UPSDisconnect()
             Case Microsoft.Win32.PowerModes.Resume
+                If UPS_Device IsNot Nothing AndAlso UPS_Device.IsConnected Then
+                    LogFile.LogTracing("Trying to disconnect connected UPS after system resume...", LogLvl.LOG_NOTICE, Me)
+                    UPSDisconnect()
+                End If
                 If My.Settings.NUT_AutoReconnect Then
-                        LogFile.LogTracing("Reconnecting after system resume.", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
-                        UPS_Connect(True)
-                    End If
+                    LogFile.LogTracing("Reconnecting after system resume.", LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_MAIN_EXITSLEEP))
+                    UPS_Connect(True)
+                End If
         End Select
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client/WinNUT.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.zh-CN.resx
@@ -102,15 +102,6 @@
   <data name="ManageOldPrefsToolStripMenuItem.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="NotifyIcon.Text" xml:space="preserve">
-    <value>NotifyIcon1</value>
-  </data>
-  <data name="Main_Menu.Text" xml:space="preserve">
-    <value>MenuStrip1</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>WinNUT Client</value>
-  </data>
   <data name="ManageOldPrefsToolStripMenuItem.Text" xml:space="preserve">
     <value>管理旧设置...</value>
   </data>

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -161,16 +161,14 @@ Public Class Nut_Socket
     ''' <summary>
     ''' Perform various functions necessary to disconnect the socket from the NUT server.
     ''' </summary>
-    ''' <param name="Forceful">Skip sending the LOGOUT command to the NUT server. Unknown effects.</param>
+    ''' <param name="forceful">Skip sending the LOGOUT command to the NUT server. Unknown effects.</param>
     Public Sub Disconnect(Optional forceful = False)
         If Not forceful AndAlso IsConnected AndAlso IsLoggedIn Then
-            Try
-                Query_Data("LOGOUT")
-            Finally
-                Close_Socket()
-                RaiseEvent SocketDisconnected()
-            End Try
+            Query_Data("LOGOUT")
         End If
+
+        Close_Socket()
+        RaiseEvent SocketDisconnected()
     End Sub
 
     ''' <summary>

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -25,7 +25,7 @@ Public Class UPS_Device
 
     Public ReadOnly Property IsConnected As Boolean
         Get
-            Return (Nut_Socket.IsConnected)
+            Return (Nut_Socket.ConnectionStatus)
         End Get
     End Property
     Public ReadOnly Property IsLoggedIn As Boolean


### PR DESCRIPTION
# Socket
- Simplified `ConnectionStatus` boolean property while maintaining null check
- Simplified NUT and Net version properties
- Removed redundant `Socket` object in favor of `TcpClient` for underlying socket management
- Removed unused `SocketDisconnected` event
- Simplify Connection logic to only do the basic work of establishing streams for reading and writing
- Gather version information immediately after successful connection, and within error tolerant try-catch blocks so as to bypass non-critical errors
- Login subroutine refers to instance fields instead of parameters (login info should never change during lifetime of the instance)
- Corrected `LOGIN` command syntax
- Disconnect subroutine is more likely to dispose of all related objects when called
- Support NUT network version 1.3

# UPS Device
- Small tweaks to properties
- Removed ReConnected event - was duplicating calls with the Connected event
- Polling interval is now read and set correctly. No longer writable after instantiation.
- Wrap Login method for socket

# WinNUT
- Remove unused `UpdateMethod` property and field
- Add support for `Suspend` system power mode change to try to prepare WinNUT for suspension (isn't always called before system suspends.)
- Reinforced `Resume` system power mode change to cleanup WinNUT's state if it was left connected while suspending previously
- WinNUT initiates the call to Login to the UPS now (support for accessing UPS without a login as intended by NUT)

## Related
- #145 
- #162 