### PR TITLE
Revert Polling Interval display to seconds

### DIFF
--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-Client.zh-TW.xlf
@@ -778,9 +778,9 @@ Cancel to Save Msi and Install Later</source>
           <source>..\Resources\WinNUT-Updater.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="final">..\Resources\WinNUT-Updater.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
-        <trans-unit id="XP_Information" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
+        <trans-unit id="XP_Information" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
-          <target state="needs-review-translation">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
+          <target state="final">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
         <trans-unit id="DetectedPreviousPrefsData" translate="yes" xml:space="preserve">
           <source>Previous preferences data detected in the Registry.</source>
@@ -1488,10 +1488,6 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>Calibration</source>
           <target state="translated">校正</target>
         </trans-unit>
-        <trans-unit id="Tb_Delay_Com.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
-          <source>12</source>
-          <target state="final">12</target>
-        </trans-unit>
         <trans-unit id="Lbl_LoadUPS.Text" translate="yes" xml:space="preserve">
           <source>UPS Load</source>
           <target state="translated">UPS 負載</target>
@@ -1756,12 +1752,6 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>Debug</source>
           <target state="translated">除錯</target>
         </trans-unit>
-        <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</source>
-          <target state="new">Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</target>
-        </trans-unit>
         <trans-unit id="Label3.ImeMode" translate="no" extype="System.Windows.Forms.ImeMode, System.Windows.Forms" xml:space="preserve">
           <source>NoControl</source>
           <target state="final">NoControl</target>
@@ -1879,10 +1869,6 @@ Accepted value: Numeric value from 0 to 3600.</source>
         <trans-unit id="Lbl_PowerF.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
           <source>92, 13</source>
           <target state="final">92, 13</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>154, 101</source>
-          <target state="final">154, 101</target>
         </trans-unit>
         <trans-unit id="Tab_Update.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>4, 22</source>
@@ -2019,10 +2005,6 @@ Accepted value: Numeric value from 0 to 3600.</source>
         <trans-unit id="Tb_Server_IP.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 11</source>
           <target state="final">154, 11</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>162, 20</source>
-          <target state="final">162, 20</target>
         </trans-unit>
         <trans-unit id="CB_Close_Tray.Text" translate="yes" xml:space="preserve">
           <source>Close to Systray</source>
@@ -2453,6 +2435,50 @@ Accepted value: Numeric value from 0 to 100.</source>
         <trans-unit id="Lbl_LoadUPS.Font" translate="yes" extype="System.Drawing.Font, System.Drawing" xml:space="preserve">
           <source>Microsoft Sans Serif, 8.25pt, style=Italic</source>
           <target state="needs-review-translation">Microsoft Sans Serif, 8.25pt, style=Italic</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Anchor" translate="yes" extype="System.Windows.Forms.AnchorStyles, System.Windows.Forms" xml:space="preserve">
+          <source>Right</source>
+          <target state="needs-review-translation">Right</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.AutoSize" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>True</source>
+          <target state="needs-review-translation">True</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>251, 102</source>
+          <target state="needs-review-translation">251, 102</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>49, 13</source>
+          <target state="needs-review-translation">49, 13</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>20</source>
+          <target state="needs-review-translation">20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Text" translate="yes" xml:space="preserve">
+          <source>Seconds</source>
+          <target state="new">Seconds</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>154, 100</source>
+          <target state="needs-review-translation">154, 100</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>91, 20</source>
+          <target state="needs-review-translation">91, 20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>19</source>
+          <target state="needs-review-translation">19</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.ToolTip" translate="yes" xml:space="preserve">
+          <source>How often WinNUT refreshes data from the NUT server.</source>
+          <target state="new">How often WinNUT refreshes data from the NUT server.</target>
+        </trans-unit>
+        <trans-unit id="Btn_Apply.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>False</source>
+          <target state="needs-review-translation">False</target>
         </trans-unit>
       </group>
     </body>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.de-DE.xlf
@@ -6,18 +6,6 @@
     </header>
     <body>
       <group id="WINNUT-CLIENT/PREF_GUI.RESX" datatype="resx">
-        <trans-unit id="Tb_Delay_Com.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>154, 101</source>
-          <target state="final">154, 101</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>162, 20</source>
-          <target state="final">162, 20</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
-          <source>12</source>
-          <target state="final">12</target>
-        </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
           <target state="final">154, 71</target>
@@ -1234,12 +1222,6 @@
           <source>17, 17</source>
           <target state="final">17, 17</target>
         </trans-unit>
-        <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</source>
-          <target state="new">Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</target>
-        </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.
 Accepted Value: Name of the UPS configured in the Nut server.</source>
@@ -1557,6 +1539,50 @@ Accepted value: Numeric value from 0 to 100.</source>
           <source>Microsoft Sans Serif, 8.25pt, style=Italic</source>
           <target state="needs-review-translation">Microsoft Sans Serif, 8.25pt, style=Italic</target>
         </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Anchor" translate="yes" extype="System.Windows.Forms.AnchorStyles, System.Windows.Forms" xml:space="preserve">
+          <source>Right</source>
+          <target state="needs-review-translation">Right</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.AutoSize" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>True</source>
+          <target state="needs-review-translation">True</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>251, 102</source>
+          <target state="needs-review-translation">251, 102</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>49, 13</source>
+          <target state="needs-review-translation">49, 13</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>20</source>
+          <target state="needs-review-translation">20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Text" translate="yes" xml:space="preserve">
+          <source>Seconds</source>
+          <target state="new">Seconds</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>154, 100</source>
+          <target state="needs-review-translation">154, 100</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>91, 20</source>
+          <target state="needs-review-translation">91, 20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>19</source>
+          <target state="needs-review-translation">19</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.ToolTip" translate="yes" xml:space="preserve">
+          <source>How often WinNUT refreshes data from the NUT server.</source>
+          <target state="new">How often WinNUT refreshes data from the NUT server.</target>
+        </trans-unit>
+        <trans-unit id="Btn_Apply.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>False</source>
+          <target state="needs-review-translation">False</target>
+        </trans-unit>
       </group>
     </body>
   </file>
@@ -1846,9 +1872,9 @@ Ini File Moved to {0}.old</source>
           <source>Windows standby. WinNUT will disconnect.</source>
           <target state="final">Windows Standby. WinNUT wird getrennt. </target>
         </trans-unit>
-        <trans-unit id="XP_Information" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
+        <trans-unit id="XP_Information" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
-          <target state="needs-review-translation">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
+          <target state="final">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
         <trans-unit id="DetectedPreviousPrefsData" translate="yes" xml:space="preserve">
           <source>Previous preferences data detected in the Registry.</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.fr-FR.xlf
@@ -6,18 +6,6 @@
     </header>
     <body>
       <group id="WINNUT-CLIENT/PREF_GUI.RESX" datatype="resx">
-        <trans-unit id="Tb_Delay_Com.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>154, 101</source>
-          <target state="final">154, 101</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>162, 20</source>
-          <target state="final">162, 20</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
-          <source>12</source>
-          <target state="final">12</target>
-        </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
           <target state="final">154, 71</target>
@@ -1237,12 +1225,6 @@ inférieur à</target>
           <source>17, 17</source>
           <target state="final">17, 17</target>
         </trans-unit>
-        <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</source>
-          <target state="new">Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</target>
-        </trans-unit>
         <trans-unit id="Tb_UPS_Name.ToolTip" translate="yes" xml:space="preserve">
           <source>UPS name to monitor.
 Accepted Value: Name of the UPS configured in the Nut server.</source>
@@ -1577,6 +1559,50 @@ Valeur acceptée: valeur numérique de 0 à 100.</target>
           <source>Microsoft Sans Serif, 8.25pt, style=Italic</source>
           <target state="needs-review-translation">Microsoft Sans Serif, 8.25pt, style=Italic</target>
         </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Anchor" translate="yes" extype="System.Windows.Forms.AnchorStyles, System.Windows.Forms" xml:space="preserve">
+          <source>Right</source>
+          <target state="needs-review-translation">Right</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.AutoSize" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>True</source>
+          <target state="needs-review-translation">True</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>251, 102</source>
+          <target state="needs-review-translation">251, 102</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>49, 13</source>
+          <target state="needs-review-translation">49, 13</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>20</source>
+          <target state="needs-review-translation">20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Text" translate="yes" xml:space="preserve">
+          <source>Seconds</source>
+          <target state="new">Seconds</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>154, 100</source>
+          <target state="needs-review-translation">154, 100</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>91, 20</source>
+          <target state="needs-review-translation">91, 20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>19</source>
+          <target state="needs-review-translation">19</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.ToolTip" translate="yes" xml:space="preserve">
+          <source>How often WinNUT refreshes data from the NUT server.</source>
+          <target state="new">How often WinNUT refreshes data from the NUT server.</target>
+        </trans-unit>
+        <trans-unit id="Btn_Apply.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>False</source>
+          <target state="needs-review-translation">False</target>
+        </trans-unit>
       </group>
     </body>
   </file>
@@ -1870,9 +1896,9 @@ Fichier Ini déplacé vers {0}.old</target>
           <source>Windows standby. WinNUT will disconnect.</source>
           <target state="final">Mise en veille de Windows. WinNUT va se déconnecter.</target>
         </trans-unit>
-        <trans-unit id="XP_Information" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
+        <trans-unit id="XP_Information" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
-          <target state="needs-review-translation">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
+          <target state="final">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
         <trans-unit id="DetectedPreviousPrefsData" translate="yes" xml:space="preserve">
           <source>Previous preferences data detected in the Registry.</source>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.ru-RU.xlf
@@ -783,9 +783,9 @@ Cancel to Save Msi and Install Later</source>
           <source>..\Resources\WinNUT-Updater.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
           <target state="final">..\Resources\WinNUT-Updater.ico;System.Drawing.Icon, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
-        <trans-unit id="XP_Information" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
+        <trans-unit id="XP_Information" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
-          <target state="needs-review-translation">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
+          <target state="final">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
         <trans-unit id="DetectedPreviousPrefsData" translate="yes" xml:space="preserve">
           <source>Previous preferences data detected in the Registry.</source>
@@ -1275,24 +1275,6 @@ along with this program. If not, see https://www.gnu.org/licenses/.</target>
         <trans-unit id="Lbl_Login_Nut.Text" translate="yes" xml:space="preserve">
           <source>Login</source>
           <target state="final">Логин</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>154, 101</source>
-          <target state="final">154, 101</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>162, 20</source>
-          <target state="final">162, 20</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
-          <source>12</source>
-          <target state="final">12</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</source>
-          <target state="new">Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
@@ -2475,6 +2457,50 @@ Accepted value: Numeric value from 0 to 100.</source>
         <trans-unit id="Lbl_LoadUPS.Font" translate="yes" extype="System.Drawing.Font, System.Drawing" xml:space="preserve">
           <source>Microsoft Sans Serif, 8.25pt, style=Italic</source>
           <target state="needs-review-translation">Microsoft Sans Serif, 8.25pt, style=Italic</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Anchor" translate="yes" extype="System.Windows.Forms.AnchorStyles, System.Windows.Forms" xml:space="preserve">
+          <source>Right</source>
+          <target state="needs-review-translation">Right</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.AutoSize" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>True</source>
+          <target state="needs-review-translation">True</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>251, 102</source>
+          <target state="needs-review-translation">251, 102</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>49, 13</source>
+          <target state="needs-review-translation">49, 13</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>20</source>
+          <target state="needs-review-translation">20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Text" translate="yes" xml:space="preserve">
+          <source>Seconds</source>
+          <target state="new">Seconds</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>154, 100</source>
+          <target state="needs-review-translation">154, 100</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>91, 20</source>
+          <target state="needs-review-translation">91, 20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>19</source>
+          <target state="needs-review-translation">19</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.ToolTip" translate="yes" xml:space="preserve">
+          <source>How often WinNUT refreshes data from the NUT server.</source>
+          <target state="new">How often WinNUT refreshes data from the NUT server.</target>
+        </trans-unit>
+        <trans-unit id="Btn_Apply.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>False</source>
+          <target state="needs-review-translation">False</target>
         </trans-unit>
       </group>
     </body>

--- a/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
+++ b/WinNUT_V2/WinNUT-Client/MultilingualResources/WinNUT-client.zh-CN.xlf
@@ -783,9 +783,9 @@ Cancel to Save Msi and Install Later</source>
           <source>Windows standby. WinNUT will disconnect.</source>
           <target state="final">Windows 待机。WinNUT 将断开连接。</target>
         </trans-unit>
-        <trans-unit id="XP_Information" translate="yes" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
+        <trans-unit id="XP_Information" translate="no" extype="System.Resources.ResXFileRef, System.Windows.Forms" xml:space="preserve">
           <source>..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</source>
-          <target state="needs-review-translation">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
+          <target state="final">..\Resources\XP_Information.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</target>
         </trans-unit>
         <trans-unit id="DetectedPreviousPrefsData" translate="yes" xml:space="preserve">
           <source>Previous preferences data detected in the Registry.</source>
@@ -1439,24 +1439,6 @@ Accepted value: Numeric value from 0 to 999.</source>
         <trans-unit id="Lbl_Login_Nut.Text" translate="yes" xml:space="preserve">
           <source>Login</source>
           <target state="final">登录</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
-          <source>154, 101</source>
-          <target state="final">154, 101</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.Size" translate="no" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
-          <source>162, 20</source>
-          <target state="final">162, 20</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.TabIndex" translate="no" extype="System.Int32, mscorlib" xml:space="preserve">
-          <source>12</source>
-          <target state="final">12</target>
-        </trans-unit>
-        <trans-unit id="Tb_Delay_Com.ToolTip" translate="yes" xml:space="preserve">
-          <source>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</source>
-          <target state="final">从NUT服务器更新数据时间间隔（单位：毫秒）。
-最小值: 100, 最大值: 60 000。</target>
         </trans-unit>
         <trans-unit id="Tb_UPS_Name.Location" translate="no" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
           <source>154, 71</source>
@@ -2474,6 +2456,50 @@ Accepted value: Numeric value from 0 to 100.</source>
         <trans-unit id="Lbl_LoadUPS.Font" translate="yes" extype="System.Drawing.Font, System.Drawing" xml:space="preserve">
           <source>Microsoft Sans Serif, 8.25pt, style=Italic</source>
           <target state="needs-review-translation">Microsoft Sans Serif, 8.25pt, style=Italic</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Anchor" translate="yes" extype="System.Windows.Forms.AnchorStyles, System.Windows.Forms" xml:space="preserve">
+          <source>Right</source>
+          <target state="needs-review-translation">Right</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.AutoSize" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>True</source>
+          <target state="needs-review-translation">True</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>251, 102</source>
+          <target state="needs-review-translation">251, 102</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>49, 13</source>
+          <target state="needs-review-translation">49, 13</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>20</source>
+          <target state="needs-review-translation">20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalUnitLabel.Text" translate="yes" xml:space="preserve">
+          <source>Seconds</source>
+          <target state="new">Seconds</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Location" translate="yes" extype="System.Drawing.Point, System.Drawing" xml:space="preserve">
+          <source>154, 100</source>
+          <target state="needs-review-translation">154, 100</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.Size" translate="yes" extype="System.Drawing.Size, System.Drawing" xml:space="preserve">
+          <source>91, 20</source>
+          <target state="needs-review-translation">91, 20</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.TabIndex" translate="yes" extype="System.Int32, mscorlib" xml:space="preserve">
+          <source>19</source>
+          <target state="needs-review-translation">19</target>
+        </trans-unit>
+        <trans-unit id="pollingIntervalValue.ToolTip" translate="yes" xml:space="preserve">
+          <source>How often WinNUT refreshes data from the NUT server.</source>
+          <target state="new">How often WinNUT refreshes data from the NUT server.</target>
+        </trans-unit>
+        <trans-unit id="Btn_Apply.Enabled" translate="yes" extype="System.Boolean, mscorlib" xml:space="preserve">
+          <source>False</source>
+          <target state="needs-review-translation">False</target>
         </trans-unit>
       </group>
     </body>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.Designer.vb
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.Designer.vb
@@ -26,12 +26,13 @@ Partial Class Pref_Gui
         Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(Pref_Gui))
         Me.TabControl_Options = New System.Windows.Forms.TabControl()
         Me.Tab_Connexion = New System.Windows.Forms.TabPage()
+        Me.pollingIntervalUnitLabel = New System.Windows.Forms.Label()
+        Me.pollingIntervalValue = New System.Windows.Forms.NumericUpDown()
         Me.Tb_Pwd_Nut = New System.Windows.Forms.TextBox()
         Me.Tb_Login_Nut = New System.Windows.Forms.TextBox()
         Me.Label3 = New System.Windows.Forms.Label()
         Me.Lbl_Pwd_Nut = New System.Windows.Forms.Label()
         Me.Lbl_Login_Nut = New System.Windows.Forms.Label()
-        Me.Tb_Delay_Com = New System.Windows.Forms.TextBox()
         Me.Tb_UPS_Name = New System.Windows.Forms.TextBox()
         Me.Tb_Port = New System.Windows.Forms.TextBox()
         Me.Tb_Server_IP = New System.Windows.Forms.TextBox()
@@ -96,6 +97,7 @@ Partial Class Pref_Gui
         Me.Pref_TlTip = New System.Windows.Forms.ToolTip(Me.components)
         Me.TabControl_Options.SuspendLayout()
         Me.Tab_Connexion.SuspendLayout()
+        CType(Me.pollingIntervalValue, System.ComponentModel.ISupportInitialize).BeginInit()
         Me.Tab_Calibrage.SuspendLayout()
         Me.Tab_Miscellanous.SuspendLayout()
         Me.Tab_Shutdown.SuspendLayout()
@@ -115,12 +117,13 @@ Partial Class Pref_Gui
         '
         'Tab_Connexion
         '
+        Me.Tab_Connexion.Controls.Add(Me.pollingIntervalUnitLabel)
+        Me.Tab_Connexion.Controls.Add(Me.pollingIntervalValue)
         Me.Tab_Connexion.Controls.Add(Me.Tb_Pwd_Nut)
         Me.Tab_Connexion.Controls.Add(Me.Tb_Login_Nut)
         Me.Tab_Connexion.Controls.Add(Me.Label3)
         Me.Tab_Connexion.Controls.Add(Me.Lbl_Pwd_Nut)
         Me.Tab_Connexion.Controls.Add(Me.Lbl_Login_Nut)
-        Me.Tab_Connexion.Controls.Add(Me.Tb_Delay_Com)
         Me.Tab_Connexion.Controls.Add(Me.Tb_UPS_Name)
         Me.Tab_Connexion.Controls.Add(Me.Tb_Port)
         Me.Tab_Connexion.Controls.Add(Me.Tb_Server_IP)
@@ -132,6 +135,21 @@ Partial Class Pref_Gui
         resources.ApplyResources(Me.Tab_Connexion, "Tab_Connexion")
         Me.Tab_Connexion.Name = "Tab_Connexion"
         Me.Tab_Connexion.UseVisualStyleBackColor = True
+        '
+        'pollingIntervalUnitLabel
+        '
+        resources.ApplyResources(Me.pollingIntervalUnitLabel, "pollingIntervalUnitLabel")
+        Me.pollingIntervalUnitLabel.Name = "pollingIntervalUnitLabel"
+        '
+        'pollingIntervalValue
+        '
+        Me.pollingIntervalValue.DecimalPlaces = 1
+        Me.pollingIntervalValue.Increment = New Decimal(New Integer() {1, 0, 0, 65536})
+        resources.ApplyResources(Me.pollingIntervalValue, "pollingIntervalValue")
+        Me.pollingIntervalValue.Minimum = New Decimal(New Integer() {1, 0, 0, 65536})
+        Me.pollingIntervalValue.Name = "pollingIntervalValue"
+        Me.Pref_TlTip.SetToolTip(Me.pollingIntervalValue, resources.GetString("pollingIntervalValue.ToolTip"))
+        Me.pollingIntervalValue.Value = New Decimal(New Integer() {1, 0, 0, 65536})
         '
         'Tb_Pwd_Nut
         '
@@ -160,12 +178,6 @@ Partial Class Pref_Gui
         '
         resources.ApplyResources(Me.Lbl_Login_Nut, "Lbl_Login_Nut")
         Me.Lbl_Login_Nut.Name = "Lbl_Login_Nut"
-        '
-        'Tb_Delay_Com
-        '
-        resources.ApplyResources(Me.Tb_Delay_Com, "Tb_Delay_Com")
-        Me.Tb_Delay_Com.Name = "Tb_Delay_Com"
-        Me.Pref_TlTip.SetToolTip(Me.Tb_Delay_Com, resources.GetString("Tb_Delay_Com.ToolTip"))
         '
         'Tb_UPS_Name
         '
@@ -602,6 +614,7 @@ Partial Class Pref_Gui
         Me.TabControl_Options.ResumeLayout(False)
         Me.Tab_Connexion.ResumeLayout(False)
         Me.Tab_Connexion.PerformLayout()
+        CType(Me.pollingIntervalValue, System.ComponentModel.ISupportInitialize).EndInit()
         Me.Tab_Calibrage.ResumeLayout(False)
         Me.Tab_Calibrage.PerformLayout()
         Me.Tab_Miscellanous.ResumeLayout(False)
@@ -630,7 +643,6 @@ Partial Class Pref_Gui
     Friend WithEvents Btn_Cancel As Button
     Friend WithEvents Tb_Server_IP As TextBox
     Friend WithEvents Tb_Port As TextBox
-    Friend WithEvents Tb_Delay_Com As TextBox
     Friend WithEvents Tb_UPS_Name As TextBox
     Friend WithEvents Lbl_InputV As Label
     Friend WithEvents Lbl_BattV As Label
@@ -684,4 +696,6 @@ Partial Class Pref_Gui
     Friend WithEvents Lbl_Pwd_Nut As Label
     Friend WithEvents Lbl_Login_Nut As Label
     Friend WithEvents CB_Follow_FSD As CheckBox
+    Friend WithEvents pollingIntervalUnitLabel As Label
+    Private WithEvents pollingIntervalValue As NumericUpDown
 End Class

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.de-DE.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.de-DE.resx
@@ -297,4 +297,31 @@
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
   </data>
+  <data name="pollingIntervalUnitLabel.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalValue.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Btn_Apply.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.fr-FR.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.fr-FR.resx
@@ -317,4 +317,31 @@ Valeur acceptée: valeur numérique de 0 à 100.</value>
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
   </data>
+  <data name="pollingIntervalUnitLabel.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalValue.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Btn_Apply.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.resx
@@ -117,11 +117,69 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="pollingIntervalUnitLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="pollingIntervalUnitLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pollingIntervalUnitLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Text" xml:space="preserve">
+    <value>Seconds</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalUnitLabel.Name" xml:space="preserve">
+    <value>pollingIntervalUnitLabel</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalUnitLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalUnitLabel.Parent" xml:space="preserve">
+    <value>Tab_Connexion</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalUnitLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="pollingIntervalValue.Location" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <metadata name="Pref_TlTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <data name="pollingIntervalValue.ToolTip" xml:space="preserve">
+    <value>How often WinNUT refreshes data from the NUT server.</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalValue.Name" xml:space="preserve">
+    <value>pollingIntervalValue</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalValue.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalValue.Parent" xml:space="preserve">
+    <value>Tab_Connexion</value>
+  </data>
+  <data name="&gt;&gt;pollingIntervalValue.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="Tb_Pwd_Nut.Location" type="System.Drawing.Point, System.Drawing">
     <value>154, 191</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Tb_Pwd_Nut.PasswordChar" type="System.Char, mscorlib" xml:space="preserve">
     <value>*</value>
   </data>
@@ -131,9 +189,6 @@
   <data name="Tb_Pwd_Nut.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
   </data>
-  <metadata name="Pref_TlTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <data name="Tb_Pwd_Nut.ToolTip" xml:space="preserve">
     <value>NUT server login password</value>
   </data>
@@ -147,7 +202,7 @@
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Tb_Pwd_Nut.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>2</value>
   </data>
   <data name="Tb_Login_Nut.Location" type="System.Drawing.Point, System.Drawing">
     <value>154, 161</value>
@@ -171,12 +226,11 @@
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Tb_Login_Nut.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="Label3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="Label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
@@ -202,7 +256,7 @@
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Label3.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>4</value>
   </data>
   <data name="Lbl_Pwd_Nut.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -232,7 +286,7 @@
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Pwd_Nut.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>5</value>
   </data>
   <data name="Lbl_Login_Nut.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -262,32 +316,7 @@
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Login_Nut.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="Tb_Delay_Com.Location" type="System.Drawing.Point, System.Drawing">
-    <value>154, 101</value>
-  </data>
-  <data name="Tb_Delay_Com.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 20</value>
-  </data>
-  <data name="Tb_Delay_Com.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>Milliseconds between data updates from NUT server.
-Min: 100, Max: 60 000.</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Name" xml:space="preserve">
-    <value>Tb_Delay_Com</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.Parent" xml:space="preserve">
-    <value>Tab_Connexion</value>
-  </data>
-  <data name="&gt;&gt;Tb_Delay_Com.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="Tb_UPS_Name.Location" type="System.Drawing.Point, System.Drawing">
     <value>154, 71</value>
@@ -312,7 +341,7 @@ Accepted Value: Name of the UPS configured in the Nut server.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Tb_UPS_Name.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="Tb_Port.Location" type="System.Drawing.Point, System.Drawing">
     <value>154, 41</value>
@@ -340,7 +369,7 @@ Accepted value: Numeric value from 1 to 65535.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Tb_Port.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="Tb_Server_IP.Location" type="System.Drawing.Point, System.Drawing">
     <value>154, 11</value>
@@ -365,7 +394,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Tb_Server_IP.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="Cb_Reconnect.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -401,7 +430,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Cb_Reconnect.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="Lbl_Delay_Com.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -428,7 +457,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Delay_Com.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="Lbl_Name_UPS.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -455,7 +484,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Name_UPS.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="Lbl_Port.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -482,7 +511,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Port.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="Lbl_Server_IP.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -512,7 +541,7 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
     <value>Tab_Connexion</value>
   </data>
   <data name="&gt;&gt;Lbl_Server_IP.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="Tab_Connexion.Location" type="System.Drawing.Point, System.Drawing">
     <value>4, 22</value>
@@ -540,6 +569,681 @@ Accepted value: IPV4 / IPV6 / FQDN address.</value>
   </data>
   <data name="&gt;&gt;Tab_Connexion.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Freq_Input.Name" xml:space="preserve">
+    <value>Cbx_Freq_Input</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Freq_Input.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Freq_Input.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Freq_Input.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Max.Name" xml:space="preserve">
+    <value>Tb_BattV_Max</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Max.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Max.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Max.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Max.Name" xml:space="preserve">
+    <value>Tb_OutV_Max</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Max.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Max.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Max.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Max.Name" xml:space="preserve">
+    <value>Tb_InF_Max</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Max.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Max.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Max.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Min.Name" xml:space="preserve">
+    <value>Tb_BattV_Min</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Min.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Min.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattV_Min.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Min.Name" xml:space="preserve">
+    <value>Tb_OutV_Min</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Min.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Min.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_OutV_Min.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Min.Name" xml:space="preserve">
+    <value>Tb_InF_Min</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Min.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Min.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_InF_Min.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Max.Name" xml:space="preserve">
+    <value>Tb_InV_Max</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Max.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Max.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Max.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Min.Name" xml:space="preserve">
+    <value>Tb_InV_Min</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Min.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Min.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tb_InV_Min.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Maxi.Name" xml:space="preserve">
+    <value>Lbl_Maxi</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Maxi.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Maxi.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Maxi.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Mini.Name" xml:space="preserve">
+    <value>Lbl_Mini</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Mini.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Mini.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Mini.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattV.Name" xml:space="preserve">
+    <value>Lbl_BattV</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattV.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattV.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LoadUPS.Name" xml:space="preserve">
+    <value>Lbl_LoadUPS</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LoadUPS.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LoadUPS.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LoadUPS.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;Lbl_OutputV.Name" xml:space="preserve">
+    <value>Lbl_OutputV</value>
+  </data>
+  <data name="&gt;&gt;Lbl_OutputV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_OutputV.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_OutputV.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputF.Name" xml:space="preserve">
+    <value>Lbl_InputF</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputF.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputF.ZOrder" xml:space="preserve">
+    <value>14</value>
+  </data>
+  <data name="&gt;&gt;Lbl_PowerF.Name" xml:space="preserve">
+    <value>Lbl_PowerF</value>
+  </data>
+  <data name="&gt;&gt;Lbl_PowerF.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_PowerF.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_PowerF.ZOrder" xml:space="preserve">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputV.Name" xml:space="preserve">
+    <value>Lbl_InputV</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputV.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputV.Parent" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Lbl_InputV.ZOrder" xml:space="preserve">
+    <value>16</value>
+  </data>
+  <data name="Tab_Calibrage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Calibrage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="Tab_Calibrage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Calibrage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="Tab_Calibrage.Text" xml:space="preserve">
+    <value>Calibration</value>
+  </data>
+  <data name="&gt;&gt;Tab_Calibrage.Name" xml:space="preserve">
+    <value>Tab_Calibrage</value>
+  </data>
+  <data name="&gt;&gt;Tab_Calibrage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Calibrage.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Calibrage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Cbx_LogLevel.Name" xml:space="preserve">
+    <value>Cbx_LogLevel</value>
+  </data>
+  <data name="&gt;&gt;Cbx_LogLevel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cbx_LogLevel.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Cbx_LogLevel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Btn_DeleteLog.Name" xml:space="preserve">
+    <value>Btn_DeleteLog</value>
+  </data>
+  <data name="&gt;&gt;Btn_DeleteLog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Btn_DeleteLog.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Btn_DeleteLog.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Btn_ViewLog.Name" xml:space="preserve">
+    <value>Btn_ViewLog</value>
+  </data>
+  <data name="&gt;&gt;Btn_ViewLog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Btn_ViewLog.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Btn_ViewLog.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LevelLog.Name" xml:space="preserve">
+    <value>Lbl_LevelLog</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LevelLog.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LevelLog.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Lbl_LevelLog.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;CB_Use_Logfile.Name" xml:space="preserve">
+    <value>CB_Use_Logfile</value>
+  </data>
+  <data name="&gt;&gt;CB_Use_Logfile.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Use_Logfile.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;CB_Use_Logfile.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_W_Win.Name" xml:space="preserve">
+    <value>CB_Start_W_Win</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_W_Win.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_W_Win.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_W_Win.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;CB_Close_Tray.Name" xml:space="preserve">
+    <value>CB_Close_Tray</value>
+  </data>
+  <data name="&gt;&gt;CB_Close_Tray.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Close_Tray.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;CB_Close_Tray.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_Mini.Name" xml:space="preserve">
+    <value>CB_Start_Mini</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_Mini.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_Mini.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;CB_Start_Mini.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;CB_Systray.Name" xml:space="preserve">
+    <value>CB_Systray</value>
+  </data>
+  <data name="&gt;&gt;CB_Systray.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Systray.Parent" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;CB_Systray.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="Tab_Miscellanous.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Miscellanous.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Miscellanous.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="Tab_Miscellanous.Text" xml:space="preserve">
+    <value>Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Name" xml:space="preserve">
+    <value>Tab_Miscellanous</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Miscellanous.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;CB_Follow_FSD.Name" xml:space="preserve">
+    <value>CB_Follow_FSD</value>
+  </data>
+  <data name="&gt;&gt;CB_Follow_FSD.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CB_Follow_FSD.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;CB_Follow_FSD.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Percent.Name" xml:space="preserve">
+    <value>Lbl_Percent</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Percent.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Percent.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Percent.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Tb_GraceTime.Name" xml:space="preserve">
+    <value>Tb_GraceTime</value>
+  </data>
+  <data name="&gt;&gt;Tb_GraceTime.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_GraceTime.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tb_GraceTime.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Cb_ExtendTime.Name" xml:space="preserve">
+    <value>Cb_ExtendTime</value>
+  </data>
+  <data name="&gt;&gt;Cb_ExtendTime.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cb_ExtendTime.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Cb_ExtendTime.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Tb_Delay_Stop.Name" xml:space="preserve">
+    <value>Tb_Delay_Stop</value>
+  </data>
+  <data name="&gt;&gt;Tb_Delay_Stop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_Delay_Stop.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tb_Delay_Stop.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Cbx_TypeStop.Name" xml:space="preserve">
+    <value>Cbx_TypeStop</value>
+  </data>
+  <data name="&gt;&gt;Cbx_TypeStop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cbx_TypeStop.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Cbx_TypeStop.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;Cb_ImmediateStop.Name" xml:space="preserve">
+    <value>Cb_ImmediateStop</value>
+  </data>
+  <data name="&gt;&gt;Cb_ImmediateStop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cb_ImmediateStop.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Cb_ImmediateStop.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Time.Name" xml:space="preserve">
+    <value>Tb_BattLimit_Time</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Time.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Time.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Time.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Load.Name" xml:space="preserve">
+    <value>Tb_BattLimit_Load</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Load.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Load.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tb_BattLimit_Load.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;Lbl_GraceTime.Name" xml:space="preserve">
+    <value>Lbl_GraceTime</value>
+  </data>
+  <data name="&gt;&gt;Lbl_GraceTime.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_GraceTime.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_GraceTime.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Stop.Name" xml:space="preserve">
+    <value>Lbl_Delay_Stop</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Stop.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Stop.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Stop.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;Lbl_StopType.Name" xml:space="preserve">
+    <value>Lbl_StopType</value>
+  </data>
+  <data name="&gt;&gt;Lbl_StopType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_StopType.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_StopType.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Time.Name" xml:space="preserve">
+    <value>Lbl_BattLimit_Time</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Time.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Time.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Time.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Load.Name" xml:space="preserve">
+    <value>Lbl_BattLimit_Load</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Load.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Load.Parent" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Lbl_BattLimit_Load.ZOrder" xml:space="preserve">
+    <value>13</value>
+  </data>
+  <data name="Tab_Shutdown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Shutdown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="Tab_Shutdown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Shutdown.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="Tab_Shutdown.Text" xml:space="preserve">
+    <value>Shutdown Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Name" xml:space="preserve">
+    <value>Tab_Shutdown</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Shutdown.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Branch_Update.Name" xml:space="preserve">
+    <value>Cbx_Branch_Update</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Branch_Update.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Branch_Update.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Branch_Update.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Delay_Verif.Name" xml:space="preserve">
+    <value>Cbx_Delay_Verif</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Delay_Verif.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Delay_Verif.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Cbx_Delay_Verif.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Branch_Update.Name" xml:space="preserve">
+    <value>Lbl_Branch_Update</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Branch_Update.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Branch_Update.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Branch_Update.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Verif.Name" xml:space="preserve">
+    <value>Lbl_Delay_Verif</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Verif.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Verif.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Lbl_Delay_Verif.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;Cb_Update_At_Start.Name" xml:space="preserve">
+    <value>Cb_Update_At_Start</value>
+  </data>
+  <data name="&gt;&gt;Cb_Update_At_Start.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cb_Update_At_Start.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Cb_Update_At_Start.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;Cb_Verify_Update.Name" xml:space="preserve">
+    <value>Cb_Verify_Update</value>
+  </data>
+  <data name="&gt;&gt;Cb_Verify_Update.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Cb_Verify_Update.Parent" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Cb_Verify_Update.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="Tab_Update.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="Tab_Update.Size" type="System.Drawing.Size, System.Drawing">
+    <value>322, 234</value>
+  </data>
+  <data name="Tab_Update.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="Tab_Update.Text" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Name" xml:space="preserve">
+    <value>Tab_Update</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.Parent" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;Tab_Update.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="TabControl_Options.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="TabControl_Options.Size" type="System.Drawing.Size, System.Drawing">
+    <value>330, 260</value>
+  </data>
+  <data name="TabControl_Options.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Name" xml:space="preserve">
+    <value>TabControl_Options</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;TabControl_Options.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="Cbx_Freq_Input.Items" xml:space="preserve">
     <value>50</value>
@@ -1002,33 +1706,6 @@ Accepted value: Numeric value from 0 to 999.</value>
   <data name="&gt;&gt;Lbl_InputV.ZOrder" xml:space="preserve">
     <value>16</value>
   </data>
-  <data name="Tab_Calibrage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Calibrage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="Tab_Calibrage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Calibrage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="Tab_Calibrage.Text" xml:space="preserve">
-    <value>Calibration</value>
-  </data>
-  <data name="&gt;&gt;Tab_Calibrage.Name" xml:space="preserve">
-    <value>Tab_Calibrage</value>
-  </data>
-  <data name="&gt;&gt;Tab_Calibrage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Calibrage.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Calibrage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="Cbx_LogLevel.Items" xml:space="preserve">
     <value>Notice</value>
   </data>
@@ -1337,30 +2014,6 @@ Accepted value: Numeric value from 0 to 999.</value>
   </data>
   <data name="&gt;&gt;CB_Systray.ZOrder" xml:space="preserve">
     <value>8</value>
-  </data>
-  <data name="Tab_Miscellanous.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Miscellanous.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Miscellanous.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="Tab_Miscellanous.Text" xml:space="preserve">
-    <value>Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Name" xml:space="preserve">
-    <value>Tab_Miscellanous</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Miscellanous.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="CB_Follow_FSD.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1770,33 +2423,6 @@ Accepted value: Numeric value from 0 to 100.</value>
   <data name="&gt;&gt;Lbl_BattLimit_Load.ZOrder" xml:space="preserve">
     <value>13</value>
   </data>
-  <data name="Tab_Shutdown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Shutdown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 0, 0</value>
-  </data>
-  <data name="Tab_Shutdown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Shutdown.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="Tab_Shutdown.Text" xml:space="preserve">
-    <value>Shutdown Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Name" xml:space="preserve">
-    <value>Tab_Shutdown</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Shutdown.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="Cbx_Branch_Update.Items" xml:space="preserve">
     <value>Stable</value>
   </data>
@@ -1986,51 +2612,6 @@ Accepted value: Numeric value from 0 to 100.</value>
   <data name="&gt;&gt;Cb_Verify_Update.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="Tab_Update.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="Tab_Update.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 234</value>
-  </data>
-  <data name="Tab_Update.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="Tab_Update.Text" xml:space="preserve">
-    <value>Update</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Name" xml:space="preserve">
-    <value>Tab_Update</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.Parent" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;Tab_Update.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="TabControl_Options.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 12</value>
-  </data>
-  <data name="TabControl_Options.Size" type="System.Drawing.Size, System.Drawing">
-    <value>330, 260</value>
-  </data>
-  <data name="TabControl_Options.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Name" xml:space="preserve">
-    <value>TabControl_Options</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;TabControl_Options.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="Btn_Ok.Location" type="System.Drawing.Point, System.Drawing">
     <value>105, 278</value>
   </data>
@@ -2054,6 +2635,9 @@ Accepted value: Numeric value from 0 to 100.</value>
   </data>
   <data name="&gt;&gt;Btn_Ok.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="Btn_Apply.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="Btn_Apply.Location" type="System.Drawing.Point, System.Drawing">
     <value>186, 278</value>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.ru-RU.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.ru-RU.resx
@@ -314,4 +314,31 @@ IPV4 / IPV6 / доменное имя.</value>
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
   </data>
+  <data name="pollingIntervalUnitLabel.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalValue.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Btn_Apply.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-CN.resx
@@ -101,10 +101,6 @@
   <data name="Lbl_Login_Nut.Text" xml:space="preserve">
     <value>登录</value>
   </data>
-  <data name="Tb_Delay_Com.ToolTip" xml:space="preserve">
-    <value>从NUT服务器更新数据时间间隔（单位：毫秒）。
-最小值: 100, 最大值: 60 000。</value>
-  </data>
   <data name="Tb_UPS_Name.ToolTip" xml:space="preserve">
     <value>监控的 UPS 名称。
 允许值：在 UPS 的 Nut 服务端所配置的名称。</value>
@@ -322,5 +318,32 @@
   </data>
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalValue.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Btn_Apply.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-TW.resx
+++ b/WinNUT_V2/WinNUT-Client/Pref_Gui.zh-TW.resx
@@ -291,4 +291,31 @@
   <data name="Lbl_LoadUPS.Font" xml:space="preserve" type="System.Drawing.Font, System.Drawing">
     <value>Microsoft Sans Serif, 8.25pt, style=Italic</value>
   </data>
+  <data name="pollingIntervalUnitLabel.Anchor" xml:space="preserve" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.AutoSize" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>251, 102</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>49, 13</value>
+  </data>
+  <data name="pollingIntervalUnitLabel.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="pollingIntervalValue.Location" xml:space="preserve" type="System.Drawing.Point, System.Drawing">
+    <value>154, 100</value>
+  </data>
+  <data name="pollingIntervalValue.Size" xml:space="preserve" type="System.Drawing.Size, System.Drawing">
+    <value>91, 20</value>
+  </data>
+  <data name="pollingIntervalValue.TabIndex" xml:space="preserve" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="Btn_Apply.Enabled" xml:space="preserve" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
 </root>

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -637,15 +637,6 @@ Public Class WinNUT
         End If
     End Sub
 
-    'TODO: FIX
-    'Public Shared Sub Event_ReConnected() Handles UPS_Device.ReConnected
-    '    With WinNUT
-    '        .Update_Data.Start()
-    '        .Device_Data = .UPS_Device.Retrieve_UPS_Datas()
-    '        .Update_UPS_Data()
-    '    End With
-    'End Sub
-
     Private Sub Update_UPS_Data() Handles UPS_Device.DataUpdated
         LogFile.LogTracing("Updating UPS data for Form.", LogLvl.LOG_DEBUG, Me)
 


### PR DESCRIPTION
- Replaced the polling interval field in the Prefs dialog with a NumericUpDown control, with precision to the tenths place and limited from 0.1 to 100.
- Updated references to the polling interval field by converting stored miliseconds to seconds and back
- Removed isModified parameter from the SavedPreferences event, the assumption being that preferences will be saved if anything was changed.
- Removed old code from WinNUT