### PR TITLE
Fix Connected toast, logged in state

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -402,10 +402,6 @@ Public Class WinNUT
         LogFile.LogTracing("Connection to Nut Host Established", LogLvl.LOG_NOTICE, Me,
                            String.Format(StrLog.Item(AppResxStr.STR_LOG_CONNECTED),
                                          upsConf.Host, upsConf.Port))
-
-        If Not String.IsNullOrEmpty(upsConf.Login) Then
-            UPS_Device.Login()
-        End If
     End Sub
 
     Private Sub ConnectionError(sender As UPS_Device, ex As Exception) Handles UPS_Device.ConnectionError

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -618,18 +618,6 @@ Public Class WinNUT
         HasFocus = False
     End Sub
 
-    Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,
-        UPS_Device.Lost_Connect, UPS_Device.Connected, UPS_Device.Disconnected
-
-        WinNUT.NotifyIcon.BalloonTipText = WinNUT.NotifyIcon.Text
-        If WinNUT.AllowToast And WinNUT.NotifyIcon.BalloonTipText <> "" Then
-            Dim Toastparts As String() = WinNUT.NotifyIcon.BalloonTipText.Split(New String() {Environment.NewLine}, StringSplitOptions.None)
-            WinNUT.ToastPopup.SendToast(Toastparts)
-        ElseIf WinNUT.NotifyIcon.Visible = True And WinNUT.NotifyIcon.BalloonTipText <> "" Then
-            WinNUT.NotifyIcon.ShowBalloonTip(10000)
-        End If
-    End Sub
-
     Private Sub Update_UPS_Data() Handles UPS_Device.DataUpdated
         LogFile.LogTracing("Updating UPS data for Form.", LogLvl.LOG_DEBUG, Me)
 
@@ -872,6 +860,18 @@ Public Class WinNUT
             NotifyIcon.Icon = GetIcon(TmpTrayIDX)
             Icon = GetIcon(TmpGuiIDX)
             LastAppIconIdx = ActualAppIconIdx
+        End If
+    End Sub
+
+    Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,
+        UPS_Device.Lost_Connect, UPS_Device.Connected, UPS_Device.Disconnected
+
+        WinNUT.NotifyIcon.BalloonTipText = WinNUT.NotifyIcon.Text
+        If WinNUT.AllowToast And WinNUT.NotifyIcon.BalloonTipText <> "" Then
+            Dim Toastparts As String() = WinNUT.NotifyIcon.BalloonTipText.Split(New String() {Environment.NewLine}, StringSplitOptions.None)
+            WinNUT.ToastPopup.SendToast(Toastparts)
+        ElseIf WinNUT.NotifyIcon.Visible = True And WinNUT.NotifyIcon.BalloonTipText <> "" Then
+            WinNUT.NotifyIcon.ShowBalloonTip(10000)
         End If
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -863,15 +863,21 @@ Public Class WinNUT
         End If
     End Sub
 
-    Public Shared Sub Event_ChangeStatus() Handles Me.On_Battery, Me.On_Line,
-        UPS_Device.Lost_Connect, UPS_Device.Connected, UPS_Device.Disconnected
+    ''' <summary>
+    ''' Handle Toast (Windows 10+) and/or NotifyIcon pop-ups.
+    ''' </summary>
+    Private Sub ToastNotifyIcon() Handles Me.On_Battery, Me.On_Line, UPS_Device.Lost_Connect,
+        UPS_Device.Connected, UPS_Device.Disconnected
 
-        WinNUT.NotifyIcon.BalloonTipText = WinNUT.NotifyIcon.Text
-        If WinNUT.AllowToast And WinNUT.NotifyIcon.BalloonTipText <> "" Then
-            Dim Toastparts As String() = WinNUT.NotifyIcon.BalloonTipText.Split(New String() {Environment.NewLine}, StringSplitOptions.None)
-            WinNUT.ToastPopup.SendToast(Toastparts)
-        ElseIf WinNUT.NotifyIcon.Visible = True And WinNUT.NotifyIcon.BalloonTipText <> "" Then
-            WinNUT.NotifyIcon.ShowBalloonTip(10000)
+        LogFile.LogTracing("ToastNotifyIcon running.", LogLvl.LOG_DEBUG, Me)
+        NotifyIcon.BalloonTipText = NotifyIcon.Text
+        If AllowToast And NotifyIcon.BalloonTipText <> "" Then
+            Dim Toastparts As String() = NotifyIcon.BalloonTipText.Split(New String() {Environment.NewLine}, StringSplitOptions.None)
+            LogFile.LogTracing("Sending Toast popup with text: " & NotifyIcon.BalloonTipText, LogLvl.LOG_DEBUG, Me)
+            ToastPopup.SendToast(Toastparts)
+        ElseIf NotifyIcon.Visible = True And NotifyIcon.BalloonTipText <> "" Then
+            LogFile.LogTracing("Sending NotifyIcon ballowtip: " & NotifyIcon.BalloonTipText, LogLvl.LOG_DEBUG, Me)
+            NotifyIcon.ShowBalloonTip(10000)
         End If
     End Sub
 

--- a/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/Nut_Socket.vb
@@ -128,6 +128,8 @@ Public Class Nut_Socket
             Query_Data("LOGOUT")
         End If
 
+        _isLoggedIn = False
+
         If WriterStream IsNot Nothing Then
             WriterStream.Dispose()
         End If

--- a/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
+++ b/WinNUT_V2/WinNUT-Client_Common/UPS_Device.vb
@@ -144,6 +144,10 @@ Public Class UPS_Device
             Update_Data.Start()
             RaiseEvent Connected(Me)
 
+            If Not String.IsNullOrEmpty(Nut_Config.Login) Then
+                Login()
+            End If
+
         Catch ex As NutException
             ' This is how we determine if we have a valid UPS name entered, among other errors.
             RaiseEvent EncounteredNUTException(Me, ex)


### PR DESCRIPTION
- Logging code added to the toast/notifyicon trigger code for troubleshooting
- Moved initial and only `Login()` call back into the UPS class to remove control logic out of the main WinNUT form and prevent exceptions from being thrown inside an event handler
  - This caused toast notify code to not be called, thus no _Connected_ toast popup.
- Properly unset logged in flag when disconnecting

Closes
- #182 

Related to
- #106