### PR TITLE
[BUGFIX] 195: Ensure battery runtime (when unavailable)  will not be used as shutdown trigger

### DIFF
--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -642,7 +642,7 @@ Public Class WinNUT
                     LogFile.LogTracing("Battery properties unavailable, unable to validate shutdown conditions.", LogLvl.LOG_WARNING, Me)
                 ElseIf Not ShutdownStatus Then
                     If .Batt_Charge <= My.Settings.PW_BattChrgFloor Or
-                        .Batt_Runtime <= My.Settings.PW_RuntimeFloor Then
+                        (.Batt_Runtime <> -1 AndAlso .Batt_Runtime <= My.Settings.PW_RuntimeFloor) Then
                         LogFile.LogTracing("UPS battery has dropped below stop condition limits.",
                                                LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_LOG_SHUT_START))
                         Shutdown_Event()

--- a/WinNUT_V2/WinNUT-Client/WinNUT.vb
+++ b/WinNUT_V2/WinNUT-Client/WinNUT.vb
@@ -641,7 +641,7 @@ Public Class WinNUT
                 If .Batt_Charge = -1 AndAlso .Batt_Runtime = -1 Then
                     LogFile.LogTracing("Battery properties unavailable, unable to validate shutdown conditions.", LogLvl.LOG_WARNING, Me)
                 ElseIf Not ShutdownStatus Then
-                    If .Batt_Charge <= My.Settings.PW_BattChrgFloor Or
+                    If (.Batt_Charge <> -1 AndAlso .Batt_Charge <= My.Settings.PW_BattChrgFloor) Or
                         (.Batt_Runtime <> -1 AndAlso .Batt_Runtime <= My.Settings.PW_RuntimeFloor) Then
                         LogFile.LogTracing("UPS battery has dropped below stop condition limits.",
                                                LogLvl.LOG_NOTICE, Me, StrLog.Item(AppResxStr.STR_LOG_SHUT_START))


### PR DESCRIPTION
…sed as a shutdown condition. Making sure when runtime is not available shutdown will not start immediately regardless of specified percentage

See: https://github.com/nutdotnet/WinNUT-Client/issues/195